### PR TITLE
feat: MCP 起動方法に uv (uv run) を追加

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -30,10 +30,10 @@ while [[ "$#" -gt 0 ]]; do
             if [[ -z "$2" || "$2" == -* ]]; then echo "Error: --mcp-output requires a value (claude|cursor|generic)"; exit 1; fi
             MCP_OUTPUT="$2"; shift ;;
         --mcp-method)
-            if [[ -z "$2" || "$2" == -* ]]; then echo "Error: --mcp-method requires a value (python|uvx)"; exit 1; fi
+            if [[ -z "$2" || "$2" == -* ]]; then echo "Error: --mcp-method requires a value (python|uv|uvx)"; exit 1; fi
             MCP_METHOD="$2"
-            if [[ "$MCP_METHOD" != "python" && "$MCP_METHOD" != "uvx" ]]; then
-                echo "Error: --mcp-method must be 'python' or 'uvx'"
+            if [[ "$MCP_METHOD" != "python" && "$MCP_METHOD" != "uv" && "$MCP_METHOD" != "uvx" ]]; then
+                echo "Error: --mcp-method must be 'python', 'uv', or 'uvx'"
                 exit 1
             fi
             shift ;;
@@ -50,7 +50,7 @@ while [[ "$#" -gt 0 ]]; do
             echo "  --embedding [openai|litellm|local|custom] Set embedding provider (default: openai)"
             echo "  --skip-tests                      Skip running unit tests"
             echo "  --mcp-output [claude|cursor|generic] Set MCP configuration output format (default: generic)"
-            echo "  --mcp-method [python|uvx]         Set MCP activation method (default: python)"
+            echo "  --mcp-method [python|uv|uvx]         Set MCP activation method (default: python)"
             echo "  --uv-from [source]                Set source for uvx (e.g. git URL or PyPI package)"
             echo "  --graph [true|false]             Enable/disable graph features (default: true)"
             echo "  -h, --help                        Show this help message"
@@ -157,7 +157,9 @@ echo -e "Next steps:"
 echo -e "1. Edit .env if you haven't already."
 echo -e "2. Use mcp_config.json to configure your MCP client (Claude Desktop/Cursor)."
 if [[ "$MCP_METHOD" == "uvx" ]]; then
-    echo -e "3. Start the server with: ${BLUE}uvx context-store${NC}"
+    echo -e "3. Start the server with: ${BLUE}uv tool run context-store${NC}"
+elif [[ "$MCP_METHOD" == "uv" ]]; then
+    echo -e "3. Start the server with: ${BLUE}uv run context-store${NC}"
 else
     echo -e "3. Start the server with: ${BLUE}python -m context_store${NC}"
 fi

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -65,10 +65,16 @@ def build_start_command(
     if method == "uvx":
         command = "uv"
         args = ["tool", "run"]
-        if uv_from:
-            args.extend(["--from", uv_from])
+        # Use provided uv_from or the default
+        actual_uv_from = uv_from or "git+https://github.com/yohi/chronos-graph.git"
+        args.extend(["--from", actual_uv_from])
         args.append("context-store")
     elif method == "uv":
+        if uv_from:
+            print(
+                "Warning: --uv-from is only used with the 'uvx' method and will be ignored for 'uv'",
+                file=sys.stderr,
+            )
         command = "uv"
         args = ["run", "context-store"]
     else:
@@ -184,7 +190,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--uv-from",
-        default="git+https://github.com/yohi/chronos-graph.git",
+        default=None,
         help="uvx モード時の --from オプション値 (デフォルト: リポジトリの Git URL)",
     )
     parser.add_argument(

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -7,15 +7,15 @@ Usage:
     python scripts/generate_config.py                    # SQLite (デフォルト)
     python scripts/generate_config.py --backend postgres # PostgreSQL モード
     python scripts/generate_config.py --output claude    # Claude Desktop 形式
-    python scripts/generate_config.py --method uvx       # uvx モード
+    python scripts/generate_config.py --method uv       # uv モード
 
 Examples:
     # Claude Desktop 設定ファイルへ追記
     python scripts/generate_config.py > /tmp/chronos-config.json
     python -m json.tool /tmp/chronos-config.json  # 検証
 
-    # uvx を使用したワンライナー設定
-    python scripts/generate_config.py --method uvx --output claude
+    # uv を使用したワンライナー設定
+    python scripts/generate_config.py --method uv --output claude
 """
 
 from __future__ import annotations
@@ -63,11 +63,14 @@ def build_start_command(
 ) -> tuple[str, list[str]]:
     """MCP サーバーを起動するためのコマンドと引数を構築する。"""
     if method == "uvx":
-        command = "uvx"
-        args = []
+        command = "uv"
+        args = ["tool", "run"]
         if uv_from:
             args.extend(["--from", uv_from])
         args.append("context-store")
+    elif method == "uv":
+        command = "uv"
+        args = ["run", "context-store"]
     else:
         command = python_path
         args = ["-m", "context_store"]
@@ -175,7 +178,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--method",
-        choices=["python", "uvx"],
+        choices=["python", "uv", "uvx"],
         default="python",
         help="MCP 起動方法 (デフォルト: python)",
     )

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -65,16 +65,14 @@ def build_start_command(
     if method == "uvx":
         command = "uv"
         args = ["tool", "run"]
-        # Use provided uv_from or the default
-        actual_uv_from = uv_from or "git+https://github.com/yohi/chronos-graph.git"
+        # Use provided uv_from or the default (pinned to a commit hash)
+        actual_uv_from = (
+            uv_from
+            or "git+https://github.com/yohi/chronos-graph.git@4666e27f5486ea86c16d7b5a4ec1c58f20d279d6"
+        )
         args.extend(["--from", actual_uv_from])
         args.append("context-store")
     elif method == "uv":
-        if uv_from:
-            print(
-                "Warning: --uv-from is only used with the 'uvx' method and will be ignored for 'uv'",
-                file=sys.stderr,
-            )
         command = "uv"
         args = ["run", "context-store"]
     else:
@@ -84,7 +82,11 @@ def build_start_command(
 
 
 def generate_sqlite_config(
-    python_path: str, embedding: str, graph: bool, method: str = "python", uv_from: str | None = None
+    python_path: str,
+    embedding: str,
+    graph: bool,
+    method: str = "python",
+    uv_from: str | None = None,
 ) -> dict:
     """SQLite ライトウェイトモードの設定を生成する。"""
     env = {
@@ -111,7 +113,11 @@ def generate_sqlite_config(
 
 
 def generate_postgres_config(
-    python_path: str, embedding: str, graph: bool, method: str = "python", uv_from: str | None = None
+    python_path: str,
+    embedding: str,
+    graph: bool,
+    method: str = "python",
+    uv_from: str | None = None,
 ) -> dict:
     """PostgreSQL + Neo4j + Redis フルモードの設定を生成する。"""
     env = {
@@ -205,6 +211,10 @@ def main() -> None:
         help="JSON インデント幅 (デフォルト: 2)",
     )
     args = parser.parse_args()
+
+    # --uv-from requires --method uvx
+    if args.uv_from is not None and args.method != "uvx":
+        parser.error("--uv-from is only supported when --method is set to 'uvx'")
 
     python_path = args.python or find_python()
     graph_enabled = args.graph


### PR DESCRIPTION
MCPサーバーの起動方法として `uv` (`uv run`) を選択できるように修正しました。また、`uvx` の挙動を `uv tool run` を使用する現代的な形式に更新しています。