### PR TITLE
fix(config): .env 設定を環境変数よりも優先するように修正

### DIFF
--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -4,13 +4,29 @@ from typing import Literal
 from urllib.parse import quote
 
 from pydantic import Field, SecretStr, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
-    model_config = {"env_prefix": "", "env_file": ".env", "extra": "ignore"}
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # .env を OS 環境変数よりも優先する
+        return init_settings, dotenv_settings, env_settings, file_secret_settings
 
     # --- Storage Backend ---
     storage_backend: Literal["sqlite", "postgres"] = "sqlite"

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -25,8 +25,8 @@ class Settings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        # OS 環境変数を .env よりも優先する(標準的な動作に戻す)
-        return init_settings, env_settings, dotenv_settings, file_secret_settings
+        # .env ファイルを OS 環境変数よりも優先する
+        return init_settings, dotenv_settings, env_settings, file_secret_settings
 
     # --- Storage Backend ---
     storage_backend: Literal["sqlite", "postgres"] = "sqlite"

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -25,8 +25,8 @@ class Settings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        # .env を OS 環境変数よりも優先する
-        return init_settings, dotenv_settings, env_settings, file_secret_settings
+        # OS 環境変数を .env よりも優先する（標準的な動作に戻す）
+        return init_settings, env_settings, dotenv_settings, file_secret_settings
 
     # --- Storage Backend ---
     storage_backend: Literal["sqlite", "postgres"] = "sqlite"

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        # OS 環境変数を .env よりも優先する（標準的な動作に戻す）
+        # OS 環境変数を .env よりも優先する(標準的な動作に戻す)
         return init_settings, env_settings, dotenv_settings, file_secret_settings
 
     # --- Storage Backend ---

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -205,15 +205,15 @@ def test_embedding_dimension_must_be_positive(default_settings):
         make_settings(embedding_dimension=-1)
 
 
-def test_settings_priority_env_over_dotenv(tmp_path, monkeypatch):
-    """OS環境変数が .env ファイルよりも優先されることを検証する。"""
+def test_settings_priority_dotenv_over_env(tmp_path, monkeypatch):
+    """.env ファイルが OS 環境変数よりも優先されることを検証する。"""
     from pydantic_settings import SettingsConfigDict
 
-    # 1. 一時的な .env ファイルを作成
+    # 1. 一時的な .env ファイルを作成 (sqlite を設定)
     dotenv_path = tmp_path / ".env"
     dotenv_path.write_text("STORAGE_BACKEND=sqlite\n")
 
-    # 2. 同じキーの環境変数を設定 (monkeypatch を使用してクリーンアップを確実にする)
+    # 2. 同じキーの環境変数を設定 (postgres を設定)
     monkeypatch.setenv("STORAGE_BACKEND", "postgres")
     monkeypatch.setenv("POSTGRES_PASSWORD", "dummy")
 
@@ -224,9 +224,9 @@ def test_settings_priority_env_over_dotenv(tmp_path, monkeypatch):
             extra="ignore",
         )
 
-    # 4. 初期化 (env_settings が優先されるはず)
+    # 4. 初期化 (.env が優先されるはず)
     # デフォルトの検証エラーを避けるため、必要なフィールドを指定
     settings = TestSettings(openai_api_key="sk-test")
 
-    # 5. 環境変数が優先されていることをアサート
-    assert settings.storage_backend == "postgres"
+    # 5. .env が優先されていることをアサート (sqlite であるはず)
+    assert settings.storage_backend == "sqlite"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -215,6 +215,7 @@ def test_settings_priority_env_over_dotenv(tmp_path, monkeypatch):
 
     # 2. 同じキーの環境変数を設定 (monkeypatch を使用してクリーンアップを確実にする)
     monkeypatch.setenv("STORAGE_BACKEND", "postgres")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "dummy")
 
     # 3. Settings を継承した一時クラスを作成し、env_file を明示的に指定
     class TestSettings(Settings):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -203,3 +203,29 @@ def test_embedding_dimension_must_be_positive(default_settings):
         make_settings(embedding_dimension=0)
     with pytest.raises(ValidationError):
         make_settings(embedding_dimension=-1)
+
+
+def test_settings_priority_env_over_dotenv(tmp_path, monkeypatch):
+    """OS環境変数が .env ファイルよりも優先されることを検証する。"""
+    from pydantic_settings import SettingsConfigDict
+
+    # 1. 一時的な .env ファイルを作成
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text("STORAGE_BACKEND=sqlite\n")
+
+    # 2. 同じキーの環境変数を設定 (monkeypatch を使用してクリーンアップを確実にする)
+    monkeypatch.setenv("STORAGE_BACKEND", "postgres")
+
+    # 3. Settings を継承した一時クラスを作成し、env_file を明示的に指定
+    class TestSettings(Settings):
+        model_config = SettingsConfigDict(
+            env_file=str(dotenv_path),
+            extra="ignore",
+        )
+
+    # 4. 初期化 (env_settings が優先されるはず)
+    # デフォルトの検証エラーを避けるため、必要なフィールドを指定
+    settings = TestSettings(openai_api_key="sk-test")
+
+    # 5. 環境変数が優先されていることをアサート
+    assert settings.storage_backend == "postgres"


### PR DESCRIPTION
## 概要
MCPサーバーの初期化時に、OSの環境変数が `.env` ファイルの設定を上書きしてしまい、
意図しない `openai` プロバイダーが選択されて初期化エラー（ハング）が発生する問題を修正しました。

## 変更内容
- `Settings` クラスに `settings_customise_sources` を実装
- 読み込み順序を変更し、`.env` ファイルを OS 環境変数よりも優先するように設定

## 影響範囲
- `local-model` など、`.env` で特定のプロバイダーを強制したい場合に、環境変数の影響を受けずに動作するようになります。