### PR TITLE
fix(dashboard): Phase 1 - 実行環境のエラー修正と設定調整

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       dockerfile: Dockerfile
     image: chronos-graph-postgres:latest
     ports:
-      - "5433:5432"
+      - "5435:5432"
     environment:
       POSTGRES_DB: context_store
       POSTGRES_USER: context_store

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
 
     # --- PostgreSQL (storage_backend=postgres の場合) ---
     postgres_host: str = "localhost"
-    postgres_port: int = 5432
+    postgres_port: int = 5435
     postgres_db: str = "context_store"
     postgres_user: str = "context_store"
     postgres_password: SecretStr = SecretStr("")
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
     local_model_name: str = "cl-nagoya/ruri-v3-310m"
     litellm_api_base: str = "http://localhost:4000"
     litellm_model: str = "openai/text-embedding-3-small"
-    embedding_dimension: int = Field(default=1536, ge=1)
+    embedding_dimension: int = Field(default=1024, ge=1)
     custom_api_endpoint: str = ""
     custom_api_model_name: str = "custom-model"
 

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -77,7 +77,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379"
 
     # --- Embedding ---
-    embedding_provider: Literal["openai", "local-model", "litellm", "custom-api"] = "openai"
+    embedding_provider: Literal["openai", "local-model", "litellm", "custom-api"] = "local-model"
     openai_api_key: SecretStr = SecretStr("")
     local_model_name: str = "cl-nagoya/ruri-v3-310m"
     litellm_api_base: str = "http://localhost:4000"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import asyncpg
 import pytest
 
 PG_HOST = os.getenv("PG_HOST", "localhost")
-PG_PORT = int(os.getenv("PG_PORT", "5433"))
+PG_PORT = int(os.getenv("PG_PORT", "5435"))
 PG_DB = os.getenv("PG_DB", "context_store")
 PG_USER = os.getenv("PG_USER", "context_store")
 PG_PASSWORD = os.getenv("PG_PASSWORD", "dev_password")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,7 +20,7 @@ def make_settings(**kwargs: Any) -> Settings:
         "cache_coherence_poll_interval_seconds": 5.0,
         "postgres_host": "localhost",
         "postgres_password": "test",
-        "postgres_port": 5432,
+        "postgres_port": 5435,
         "postgres_user": "postgres",
         "postgres_db": "testdb",
         "redis_url": "redis://localhost:6379",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -27,7 +27,7 @@ def test_default_settings(monkeypatch, default_settings):
 
     # _env_file=None を指定して、.env ファイルの読み込みも回避する
     settings = Settings(_env_file=None, openai_api_key=default_settings["openai_api_key"])
-    assert settings.postgres_port == 5432
+    assert settings.postgres_port == 5435
     assert settings.embedding_provider == "local-model"
     assert settings.decay_half_life_days == 30
     assert settings.archive_threshold == 0.05
@@ -154,7 +154,7 @@ def test_postgres_dsn_url_encodes_credentials(default_settings):
     )
 
     assert settings.postgres_dsn == (
-        "postgresql://user%2Bname%40example.com:p%40ss%20word%3A%2F@localhost:5432/context%2Fstore%20prod"
+        "postgresql://user%2Bname%40example.com:p%40ss%20word%3A%2F@localhost:5435/context%2Fstore%20prod"
     )
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,7 +28,7 @@ def test_default_settings(monkeypatch, default_settings):
     # _env_file=None を指定して、.env ファイルの読み込みも回避する
     settings = Settings(_env_file=None, openai_api_key=default_settings["openai_api_key"])
     assert settings.postgres_port == 5432
-    assert settings.embedding_provider == "openai"
+    assert settings.embedding_provider == "local-model"
     assert settings.decay_half_life_days == 30
     assert settings.archive_threshold == 0.05
     assert settings.similarity_threshold == 0.70


### PR DESCRIPTION
- EMBEDDING_PROVIDERのデフォルト値を local-model に変更しました。
- PostgreSQLポートの競合を回避するため、docker-compose.ymlと統合テストで使用するポートを 5435 に変更しました。
- test_config.pyの設定値テストを最新の仕様に合わせて修正しました。