### PR TITLE
feat(ingestion): TaskRegistry を追加 — バックグラウンドタスク管理

### DIFF
--- a/src/context_store/ingestion/task_registry.py
+++ b/src/context_store/ingestion/task_registry.py
@@ -1,0 +1,76 @@
+"""TaskRegistry: バックグラウンド asyncio.Task のライフサイクル管理。
+
+バッチ処理等のバックグラウンドタスクを追跡し、
+graceful shutdown 時の一括キャンセルを提供する。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TaskRegistry:
+    """In-memory registry of running asyncio.Task objects.
+
+    Sole purpose: track background tasks for graceful shutdown cancellation.
+    No state tracking, no history, no progress monitoring.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    def register(self, task: asyncio.Task[None]) -> None:
+        """Register a task. Add done_callback for auto-removal and error logging.
+
+        done_callback implementation:
+        1. self._tasks.discard(task) で自身を除去
+        2. task.cancelled() を確認
+           - True の場合: logger.debug() で正常キャンセルとして記録 → 終了
+        3. task.exception() で未処理例外を取得
+           - 例外が存在する場合: logger.error() でスタックトレース付きログ出力
+           - 例外なしの場合: logger.debug() で正常完了を記録
+        4. 例外は再送出しない（バックグラウンドタスクのため呼び出し元に伝播不可）
+
+        Note: task.cancelled() を先行チェックしないと、キャンセル済みタスクに対して
+        task.exception() を呼んだ際に CancelledError が送出されるため順序は重要。
+        """
+        self._tasks.add(task)
+        task.add_done_callback(self._on_task_done)
+
+    def __len__(self) -> int:
+        """Return the number of currently running tasks."""
+        return len(self._tasks)
+
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        """Done callback: auto-remove task and log errors."""
+        self._tasks.discard(task)
+
+        if task.cancelled():
+            logger.debug("Background task cancelled: %s", task.get_name())
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Background task failed: %s: %s",
+                task.get_name(),
+                exc,
+                exc_info=exc,
+            )
+        else:
+            logger.debug("Background task completed: %s", task.get_name())
+
+    async def cancel_all(self, timeout: float = 5.0) -> None:
+        """Cancel all running tasks with timeout. Called during graceful shutdown."""
+        if not self._tasks:
+            return
+
+        tasks = list(self._tasks)
+        for task in tasks:
+            task.cancel()
+
+        # タスクの完了を待機（タイムアウト付き）
+        await asyncio.wait(tasks, timeout=timeout)

--- a/src/context_store/ingestion/task_registry.py
+++ b/src/context_store/ingestion/task_registry.py
@@ -72,6 +72,25 @@ class TaskRegistry:
                 exc_info=e,
             )
 
+    async def wait_all(self, timeout: float = 5.0) -> None:
+        """Wait for all running tasks to complete with timeout.
+
+        If timeout is reached, remaining tasks are NOT cancelled by this method.
+        Use cancel_all() if you want to ensure all tasks are terminated.
+        """
+        if not self._tasks:
+            return
+
+        tasks = list(self._tasks)
+        _done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            logger.warning(
+                "wait_all: %d task(s) did not finish within timeout=%.1fs: %s",
+                len(pending),
+                timeout,
+                [t.get_name() for t in pending],
+            )
+
     async def cancel_all(self, timeout: float = 5.0) -> None:
         """Cancel all running tasks with timeout. Called during graceful shutdown."""
         if not self._tasks:
@@ -81,8 +100,8 @@ class TaskRegistry:
         for task in tasks:
             task.cancel()
 
-        # タスクの完了を待機（タイムアウト付き）
-        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        # タスクの完了を待機 (タイムアウト付き)
+        _done, pending = await asyncio.wait(tasks, timeout=timeout)
         if pending:
             logger.warning(
                 "cancel_all: %d task(s) did not finish within timeout=%.1fs: %s",

--- a/src/context_store/ingestion/task_registry.py
+++ b/src/context_store/ingestion/task_registry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +21,9 @@ class TaskRegistry:
     """
 
     def __init__(self) -> None:
-        self._tasks: set[asyncio.Task[None]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
 
-    def register(self, task: asyncio.Task[None]) -> None:
+    def register(self, task: asyncio.Task[Any]) -> None:
         """Register a task. Add done_callback for auto-removal and error logging.
 
         done_callback implementation:
@@ -44,7 +45,7 @@ class TaskRegistry:
         """Return the number of currently running tasks."""
         return len(self._tasks)
 
-    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+    def _on_task_done(self, task: asyncio.Task[Any]) -> None:
         """Done callback: auto-remove task and log errors."""
         self._tasks.discard(task)
 
@@ -73,4 +74,11 @@ class TaskRegistry:
             task.cancel()
 
         # タスクの完了を待機（タイムアウト付き）
-        await asyncio.wait(tasks, timeout=timeout)
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            task_names = [t.get_name() for t in pending]
+            logger.warning(
+                "Some background tasks did not terminate within %.1f seconds: %s",
+                timeout,
+                ", ".join(task_names),
+            )

--- a/src/context_store/ingestion/task_registry.py
+++ b/src/context_store/ingestion/task_registry.py
@@ -33,7 +33,7 @@ class TaskRegistry:
         3. task.exception() で未処理例外を取得
            - 例外が存在する場合: logger.error() でスタックトレース付きログ出力
            - 例外なしの場合: logger.debug() で正常完了を記録
-        4. 例外は再送出しない（バックグラウンドタスクのため呼び出し元に伝播不可）
+        4. 例外は再送出しない (バックグラウンドタスクのため呼び出し元に伝播不可)
 
         Note: task.cancelled() を先行チェックしないと、キャンセル済みタスクに対して
         task.exception() を呼んだ際に CancelledError が送出されるため順序は重要。
@@ -49,20 +49,28 @@ class TaskRegistry:
         """Done callback: auto-remove task and log errors."""
         self._tasks.discard(task)
 
-        if task.cancelled():
-            logger.debug("Background task cancelled: %s", task.get_name())
-            return
+        try:
+            if task.cancelled():
+                logger.debug("Background task cancelled: %s", task.get_name())
+                return
 
-        exc = task.exception()
-        if exc is not None:
+            exc = task.exception()
+            if exc is not None:
+                logger.error(
+                    "Background task failed: %s: %s",
+                    task.get_name(),
+                    exc,
+                    exc_info=exc,
+                )
+            else:
+                logger.debug("Background task completed: %s", task.get_name())
+        except Exception as e:
             logger.error(
-                "Background task failed: %s: %s",
+                "Error in TaskRegistry._on_task_done for task %s: %s",
                 task.get_name(),
-                exc,
-                exc_info=exc,
+                e,
+                exc_info=e,
             )
-        else:
-            logger.debug("Background task completed: %s", task.get_name())
 
     async def cancel_all(self, timeout: float = 5.0) -> None:
         """Cancel all running tasks with timeout. Called during graceful shutdown."""
@@ -76,9 +84,9 @@ class TaskRegistry:
         # タスクの完了を待機（タイムアウト付き）
         done, pending = await asyncio.wait(tasks, timeout=timeout)
         if pending:
-            task_names = [t.get_name() for t in pending]
             logger.warning(
-                "Some background tasks did not terminate within %.1f seconds: %s",
+                "cancel_all: %d task(s) did not finish within timeout=%.1fs: %s",
+                len(pending),
                 timeout,
-                ", ".join(task_names),
+                [t.get_name() for t in pending],
             )

--- a/src/context_store/lifecycle/manager.py
+++ b/src/context_store/lifecycle/manager.py
@@ -17,6 +17,7 @@ from context_store.storage.protocols import MemoryFilters
 
 if TYPE_CHECKING:
     from context_store.config import Settings
+    from context_store.ingestion.task_registry import TaskRegistry
     from context_store.lifecycle.archiver import Archiver
     from context_store.lifecycle.consolidator import Consolidator
     from context_store.lifecycle.decay_scorer import DecayScorer
@@ -70,7 +71,7 @@ class WalState:
         wal_failure_count: WAL チェックポイントの累積失敗数。
         wal_last_failure_ts: 最後に失敗した日時（UTC）。
         wal_last_checkpoint_result: 最後のチェックポイント結果テキスト。
-        wal_last_observed_size_bytes: 最後に観測した WAL ファイルサイズ（バイト）。
+        wal_last、observed_size_bytes: 最後に観測した WAL ファイルサイズ（バイト）。
         wal_consecutive_passive_failures: PASSIVE モードの連続失敗回数。
         wal_failure_window: スライディングウィンドウ（失敗日時のリスト）。
     """
@@ -622,6 +623,7 @@ class LifecycleManager:
         consolidator: コンソリデーター。
         decay_scorer: 減衰スコアラー。
         storage: ストレージアダプター（統計収集用）。
+        task_registry: バックグラウンドタスクレジストリ。
         settings: アプリケーション設定。省略時はデフォルト値を使用。
         lock_path: OS レベルのファイルロックパス。
         wal_checkpoint_fn: WAL チェックポイント実行関数。None の場合はスキップ。
@@ -635,6 +637,7 @@ class LifecycleManager:
         consolidator: "Consolidator",
         decay_scorer: "DecayScorer",
         storage: "StorageAdapter",
+        task_registry: "TaskRegistry",
         settings: "Settings | None" = None,
         lock_path: str = ".lifecycle.lock",
         wal_checkpoint_fn: "WalCheckpointFn | None" = None,
@@ -645,8 +648,11 @@ class LifecycleManager:
         self._consolidator = consolidator
         self._decay_scorer = decay_scorer
         self._storage = storage
+        self._task_registry = task_registry
         self._lock_path = lock_path
         self._wal_checkpoint_fn = wal_checkpoint_fn
+
+        self._shutting_down = False
 
         if settings is None:
             from context_store.config import Settings
@@ -667,9 +673,6 @@ class LifecycleManager:
         )
         self._wal_checkpoint_mode_passive = settings.wal_checkpoint_mode_passive
         self._wal_checkpoint_mode_truncate = settings.wal_checkpoint_mode_truncate
-
-        self._active_tasks: list[asyncio.Task[None]] = []
-        self._shutting_down = False
 
     async def start(self) -> None:
         """MCPサーバー起動時に呼び出す。時間ベースのクリーンアップチェックをスケジュール。
@@ -694,10 +697,6 @@ class LifecycleManager:
                     should_run = True
 
             if should_run:
-                # シャットダウン中であれば実行しない
-                if getattr(self, "_shutting_down", False):
-                    return
-
                 logger.info(
                     "Time-based cleanup triggered (last_cleanup_at=%s).", state.last_cleanup_at
                 )
@@ -706,26 +705,12 @@ class LifecycleManager:
             logger.exception("Time-based cleanup check failed.")
 
     def _spawn_background_task(self, factory: Callable[[], Coroutine[Any, Any, Any]]) -> None:
-        """例外ハンドリング付きでバックグラウンドタスクを開始する。"""
-        if getattr(self, "_shutting_down", False):
+        """TaskRegistry を使用してバックグラウンドタスクを開始する。"""
+        if self._shutting_down:
             return
 
-        task: asyncio.Task[None] = asyncio.create_task(factory())
-        self._active_tasks.append(task)
-
-        def done_callback(t: asyncio.Task[None]) -> None:
-            if t in self._active_tasks:
-                self._active_tasks.remove(t)
-            try:
-                # 例外が発生していた場合はログに記録
-                if not t.cancelled():
-                    exc = t.exception()
-                    if exc:
-                        logger.error("Background task failed: %s", exc, exc_info=True)
-            except asyncio.InvalidStateError:
-                pass
-
-        task.add_done_callback(done_callback)
+        task = asyncio.create_task(factory())
+        self._task_registry.register(task)
 
     async def _check_lock_integrity(self, token: str) -> None:
         """現在のロック所有者が自身であることを確認する。
@@ -1097,27 +1082,10 @@ class LifecycleManager:
         return wal_state
 
     async def graceful_shutdown(self) -> None:
-        """進行中のタスクをタイムアウト付きで完了待機する（最大 5 秒）。"""
+        """進行中のタスクをタイムアウト付きで完了待機する。タイムアウト時は強制キャンセルする。"""
         self._shutting_down = True
-
-        if not self._active_tasks:
-            return
-
-        logger.info("Graceful shutdown: waiting for task(s)...")
-        start_time = asyncio.get_event_loop().time()
-        try:
-            while self._active_tasks:
-                if asyncio.get_event_loop().time() - start_time >= 5.0:
-                    raise asyncio.TimeoutError()
-                tasks = list(self._active_tasks)
-                await asyncio.wait_for(
-                    asyncio.gather(*tasks, return_exceptions=True),
-                    timeout=5.0 - (asyncio.get_event_loop().time() - start_time),
-                )
-        except asyncio.TimeoutError:
-            logger.warning("Graceful shutdown timed out, cancelling remaining tasks.")
-            for task in list(self._active_tasks):
-                if not task.done():
-                    task.cancel()
-            # キャンセルされたタスクが終了（およびクリーンアップ）するのを待機
-            await asyncio.gather(*list(self._active_tasks), return_exceptions=True)
+        # まずは完了を待機
+        await self._task_registry.wait_all(timeout=5.0)
+        # それでも残っている場合はキャンセル
+        if len(self._task_registry) > 0:
+            await self._task_registry.cancel_all(timeout=1.0)

--- a/src/context_store/lifecycle/manager.py
+++ b/src/context_store/lifecycle/manager.py
@@ -1089,3 +1089,10 @@ class LifecycleManager:
         # それでも残っている場合はキャンセル
         if len(self._task_registry) > 0:
             await self._task_registry.cancel_all(timeout=1.0)
+
+        # 最終チェック: それでもタスクが残っている場合はエラーとして報告
+        remaining = len(self._task_registry)
+        if remaining > 0:
+            msg = f"graceful_shutdown: {remaining} task(s) still remain after cancellation"
+            logger.error(msg)
+            raise RuntimeError(msg)

--- a/src/context_store/lifecycle/manager.py
+++ b/src/context_store/lifecycle/manager.py
@@ -71,7 +71,7 @@ class WalState:
         wal_failure_count: WAL チェックポイントの累積失敗数。
         wal_last_failure_ts: 最後に失敗した日時（UTC）。
         wal_last_checkpoint_result: 最後のチェックポイント結果テキスト。
-        wal_last、observed_size_bytes: 最後に観測した WAL ファイルサイズ（バイト）。
+        wal_last_observed_size_bytes: 最後に観測した WAL ファイルサイズ (バイト)。
         wal_consecutive_passive_failures: PASSIVE モードの連続失敗回数。
         wal_failure_window: スライディングウィンドウ（失敗日時のリスト）。
     """

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -342,10 +342,12 @@ class Orchestrator:
 
     async def dispose(self) -> None:
         """全アダプターのリソースを解放する。"""
-        # まずバックグラウンドタスクをキャンセル
+        # まずライフサイクルマネージャーを終了させ、タスクの完了を待機する
+        await self._lifecycle_manager.graceful_shutdown()
+
+        # 残っているバックグラウンドタスクがあればキャンセル（5s タイムアウト）
         await self._task_registry.cancel_all(timeout=5.0)
 
-        await self._lifecycle_manager.graceful_shutdown()
         await self._storage.dispose()
         if self._graph is not None:
             await self._graph.dispose()

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -345,7 +345,7 @@ class Orchestrator:
         # まずライフサイクルマネージャーを終了させ、タスクの完了を待機する
         await self._lifecycle_manager.graceful_shutdown()
 
-        # 残っているバックグラウンドタスクがあればキャンセル（5s タイムアウト）
+        # 残っているバックグラウンドタスクがあればキャンセル (5s タイムアウト)
         await self._task_registry.cancel_all(timeout=5.0)
 
         await self._storage.dispose()

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -343,7 +343,10 @@ class Orchestrator:
     async def dispose(self) -> None:
         """全アダプターのリソースを解放する。"""
         # まずライフサイクルマネージャーを終了させ、タスクの完了を待機する
-        await self._lifecycle_manager.graceful_shutdown()
+        try:
+            await self._lifecycle_manager.graceful_shutdown()
+        except Exception as exc:
+            logger.warning("Graceful shutdown incomplete (ignored): %s", exc)
 
         # 残っているバックグラウンドタスクがあればキャンセル (5s タイムアウト)
         await self._task_registry.cancel_all(timeout=5.0)

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from context_store.embedding.protocols import EmbeddingProvider
     from context_store.extensions.protocols import ActionLogger, PolicyHook, RewardSignal
     from context_store.ingestion.pipeline import IngestionPipeline, IngestionResult
+    from context_store.ingestion.task_registry import TaskRegistry
     from context_store.lifecycle.manager import LifecycleManager
     from context_store.retrieval.pipeline import RetrievalPipeline, RetrievalResponse
     from context_store.storage.protocols import CacheAdapter, GraphAdapter, StorageAdapter
@@ -43,6 +44,7 @@ class Orchestrator:
         ingestion_pipeline: 取り込みパイプライン。
         retrieval_pipeline: 検索パイプライン。
         lifecycle_manager: ライフサイクルマネージャー。
+        task_registry: タスクレジストリ。
         action_logger: RL 拡張: アクションロガー（None の場合は NoOp）。
         reward_signal: RL 拡張: 報酬シグナル（None の場合は NoOp）。
         policy_hook: RL 拡張: 検索戦略フック（None の場合は NoOp）。
@@ -58,6 +60,7 @@ class Orchestrator:
         ingestion_pipeline: "IngestionPipeline",
         retrieval_pipeline: "RetrievalPipeline",
         lifecycle_manager: "LifecycleManager",
+        task_registry: "TaskRegistry",
         action_logger: "ActionLogger | None" = None,
         reward_signal: "RewardSignal | None" = None,
         policy_hook: "PolicyHook | None" = None,
@@ -70,6 +73,7 @@ class Orchestrator:
         self._ingestion_pipeline = ingestion_pipeline
         self._retrieval_pipeline = retrieval_pipeline
         self._lifecycle_manager = lifecycle_manager
+        self._task_registry = task_registry
         self._settings = settings
 
         # RL 拡張フック（None の場合は NoOp）
@@ -338,6 +342,9 @@ class Orchestrator:
 
     async def dispose(self) -> None:
         """全アダプターのリソースを解放する。"""
+        # まずバックグラウンドタスクをキャンセル
+        await self._task_registry.cancel_all(timeout=5.0)
+
         await self._lifecycle_manager.graceful_shutdown()
         await self._storage.dispose()
         if self._graph is not None:
@@ -374,6 +381,7 @@ async def create_orchestrator(
     """
     from context_store.embedding import create_embedding_provider
     from context_store.ingestion.pipeline import IngestionPipeline
+    from context_store.ingestion.task_registry import TaskRegistry
     from context_store.lifecycle.archiver import Archiver
     from context_store.lifecycle.consolidator import Consolidator
     from context_store.lifecycle.decay_scorer import DecayScorer
@@ -462,6 +470,7 @@ async def create_orchestrator(
             graph=graph,
             retention_days=settings.purge_retention_days,
         )
+        task_registry = TaskRegistry()
         lifecycle_manager = LifecycleManager(
             state_store=state_store,
             archiver=archiver,
@@ -469,6 +478,7 @@ async def create_orchestrator(
             consolidator=consolidator,
             decay_scorer=decay_scorer,
             storage=storage,
+            task_registry=task_registry,
             settings=settings,
         )
 
@@ -481,6 +491,7 @@ async def create_orchestrator(
             ingestion_pipeline=ingestion_pipeline,
             retrieval_pipeline=retrieval_pipeline,
             lifecycle_manager=lifecycle_manager,
+            task_registry=task_registry,
             action_logger=action_logger,
             reward_signal=reward_signal,
             policy_hook=policy_hook,

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -345,8 +345,8 @@ class Orchestrator:
         # まずライフサイクルマネージャーを終了させ、タスクの完了を待機する
         try:
             await self._lifecycle_manager.graceful_shutdown()
-        except Exception as exc:
-            logger.warning("Graceful shutdown incomplete (ignored): %s", exc)
+        except RuntimeError as exc:
+            logger.warning("Graceful shutdown incomplete (ignored): %s", exc, exc_info=True)
 
         # 残っているバックグラウンドタスクがあればキャンセル (5s タイムアウト)
         await self._task_registry.cancel_all(timeout=5.0)

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -211,8 +211,7 @@ class TestRunCleanup:
             await manager.on_memory_saved()
 
         # バックグラウンドタスクの完了を待機 (TaskRegistry 経由)
-        # 内部プロパティ _tasks にアクセスして待機
-        await asyncio.gather(*list(manager._task_registry._tasks))
+        await manager._task_registry.wait_all()
 
         # ロック喪失により中断されたため、last_cleanup_at が更新されていないことを確認
         final_state = await state_store.load_state()
@@ -558,9 +557,8 @@ class TestGracefulShutdown:
         task = asyncio.create_task(long_task())
         manager._task_registry.register(task)
 
-        # 5秒タイムアウト付きで完了すること
-        # TaskRegistry.cancel_all が 5s でキャンセルする
-        await asyncio.wait_for(manager.graceful_shutdown(), timeout=6.0)
+        # 10秒タイムアウト付きで完了すること (CI 安定化のため)
+        await asyncio.wait_for(manager.graceful_shutdown(), timeout=10.0)
 
         # タスクがキャンセルされていること
         assert task.cancelled()

--- a/tests/unit/test_lifecycle_manager.py
+++ b/tests/unit/test_lifecycle_manager.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from context_store.ingestion.task_registry import TaskRegistry
 from context_store.lifecycle.manager import (
     InMemoryLifecycleStateStore,
     LifecycleManager,
@@ -47,12 +48,16 @@ def _make_manager(
     stale_lock_timeout_seconds: int = 600,
     wal_checkpoint_fn=None,
     lock_path: str = ".lifecycle.lock",
+    task_registry: TaskRegistry | None = None,
 ) -> tuple[LifecycleManager, InMemoryLifecycleStateStore]:
     """テスト用 LifecycleManager を生成するヘルパー。"""
     if state_store is None:
         state_store = InMemoryLifecycleStateStore(
             stale_lock_timeout_seconds=stale_lock_timeout_seconds
         )
+
+    if task_registry is None:
+        task_registry = TaskRegistry()
 
     archiver = AsyncMock()
     archiver.run = AsyncMock(return_value=MagicMock(archived_count=0, checked_count=0))
@@ -91,6 +96,7 @@ def _make_manager(
         consolidator=consolidator,
         decay_scorer=decay_scorer,
         storage=storage,
+        task_registry=task_registry,
         settings=settings,
         lock_path=lock_path,
         wal_checkpoint_fn=wal_checkpoint_fn,
@@ -204,8 +210,9 @@ class TestRunCleanup:
         for _ in range(50):
             await manager.on_memory_saved()
 
-        # バックグラウンドタスクの完了を待機
-        await asyncio.gather(*manager._active_tasks)
+        # バックグラウンドタスクの完了を待機 (TaskRegistry 経由)
+        # 内部プロパティ _tasks にアクセスして待機
+        await asyncio.gather(*list(manager._task_registry._tasks))
 
         # ロック喪失により中断されたため、last_cleanup_at が更新されていないことを確認
         final_state = await state_store.load_state()
@@ -520,7 +527,7 @@ class TestGracefulShutdown:
         """タスクがない場合はシャットダウンが即座に完了すること。"""
         manager, _ = _make_manager()
         # アクティブタスクなし
-        assert len(manager._active_tasks) == 0
+        assert len(manager._task_registry) == 0
 
         # タイムアウトなしで即時完了すること
         await asyncio.wait_for(manager.graceful_shutdown(), timeout=1.0)
@@ -536,7 +543,7 @@ class TestGracefulShutdown:
             completed.append(True)
 
         task = asyncio.create_task(slow_task())
-        manager._active_tasks.append(task)
+        manager._task_registry.register(task)
 
         await manager.graceful_shutdown()
         assert len(completed) == 1
@@ -549,9 +556,10 @@ class TestGracefulShutdown:
             await asyncio.sleep(10)  # 5秒を超えるタスク
 
         task = asyncio.create_task(long_task())
-        manager._active_tasks.append(task)
+        manager._task_registry.register(task)
 
-        # 5秒タイムアウト付きで完了すること（TimeoutError が内部で処理される）
+        # 5秒タイムアウト付きで完了すること
+        # TaskRegistry.cancel_all が 5s でキャンセルする
         await asyncio.wait_for(manager.graceful_shutdown(), timeout=6.0)
 
         # タスクがキャンセルされていること
@@ -834,6 +842,7 @@ async def test_spawn_background_task_no_leak():
     mock_consolidator = MagicMock()
     mock_decay = MagicMock()
     mock_storage = MagicMock()
+    mock_registry = MagicMock()
 
     manager = LifecycleManager(
         state_store=mock_store,
@@ -842,6 +851,7 @@ async def test_spawn_background_task_no_leak():
         consolidator=mock_consolidator,
         decay_scorer=mock_decay,
         storage=mock_storage,
+        task_registry=mock_registry,
         settings=MagicMock(),
     )
 
@@ -857,4 +867,4 @@ async def test_spawn_background_task_no_leak():
 
     # The factory shouldn't be called, so the coroutine is never created, hence no leak.
     task_factory.assert_not_called()
-    assert len(manager._active_tasks) == 0
+    mock_registry.register.assert_not_called()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -95,6 +95,15 @@ def _make_mock_lifecycle_manager() -> MagicMock:
     return manager
 
 
+def _make_mock_task_registry() -> MagicMock:
+    """TaskRegistry モックを生成する。"""
+    registry = AsyncMock()
+    registry.register = MagicMock()
+    registry.cancel_all = AsyncMock()
+    registry.__len__ = MagicMock(return_value=0)
+    return registry
+
+
 async def _build_orchestrator(
     *,
     storage=None,
@@ -104,6 +113,7 @@ async def _build_orchestrator(
     ingestion_pipeline=None,
     retrieval_pipeline=None,
     lifecycle_manager=None,
+    task_registry=None,
     action_logger=None,
     reward_signal=None,
     policy_hook=None,
@@ -123,6 +133,7 @@ async def _build_orchestrator(
     ingestion_pipeline = ingestion_pipeline or _make_mock_ingestion_pipeline()
     retrieval_pipeline = retrieval_pipeline or _make_mock_retrieval_pipeline()
     lifecycle_manager = lifecycle_manager or _make_mock_lifecycle_manager()
+    task_registry = task_registry or _make_mock_task_registry()
     settings = settings or make_settings()
 
     orch = Orchestrator(
@@ -133,6 +144,7 @@ async def _build_orchestrator(
         ingestion_pipeline=ingestion_pipeline,
         retrieval_pipeline=retrieval_pipeline,
         lifecycle_manager=lifecycle_manager,
+        task_registry=task_registry,
         action_logger=action_logger,
         reward_signal=reward_signal,
         policy_hook=policy_hook,
@@ -149,6 +161,7 @@ async def _build_orchestrator(
         ingestion_pipeline,
         retrieval_pipeline,
         lifecycle_manager,
+        task_registry,
     )
 
 
@@ -533,3 +546,13 @@ class TestDisposeOperation:
         await orch.dispose()
 
         lifecycle.graceful_shutdown.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispose_calls_task_registry_cancel_all(self):
+        """dispose() が TaskRegistry.cancel_all() を呼び出す。"""
+        task_registry = _make_mock_task_registry()
+        orch, *_ = await _build_orchestrator(task_registry=task_registry)
+
+        await orch.dispose()
+
+        task_registry.cancel_all.assert_called_once()

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -62,7 +62,7 @@ class TestTaskRegistryRegister:
 
     @pytest.mark.asyncio
     async def test_register_task_with_return_value(self) -> None:
-        """Any 型のタスク（戻り値あり）を register できる。"""
+        """Any 型のタスク(戻り値あり)を register できる。"""
         registry = TaskRegistry()
 
         async def returns_bool() -> bool:
@@ -181,7 +181,7 @@ class TestTaskRegistryCancelAll:
         # cancel_all がハングせずに戻ることを確認
 
         await asyncio.sleep(0)
-        # stubborn タスクは CancelledError を握り潰して正常終了する（cancelled ではない）
+        # stubborn タスクは CancelledError を握り潰して正常終了する (cancelled ではない)
         assert task.done()
         assert not task.cancelled()
         assert len(registry) == 0
@@ -217,6 +217,57 @@ class TestTaskRegistryCancelAll:
         )
 
         # 後片付け（テストが終わった後にタスクが残らないようにする）
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_wait_all_waits_for_completion(self) -> None:
+        """wait_all() は全タスクの完了を待機する。"""
+        registry = TaskRegistry()
+        completed = []
+
+        async def slow_task() -> None:
+            await asyncio.sleep(0.1)
+            completed.append(True)
+
+        task = asyncio.create_task(slow_task())
+        registry.register(task)
+
+        await registry.wait_all(timeout=0.5)
+        assert len(completed) == 1
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_wait_all_does_not_cancel_on_timeout(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """wait_all() はタイムアウトしてもタスクをキャンセルしない。"""
+        registry = TaskRegistry()
+
+        async def stubborn() -> None:
+            await asyncio.sleep(1.0)
+
+        task = asyncio.create_task(stubborn())
+        registry.register(task)
+
+        # タイムアウト 0.1s で wait_all
+        await registry.wait_all(timeout=0.1)
+
+        # タイムアウトしてもタスクは生きている (キャンセルされていない)
+        assert not task.done()
+        assert not task.cancelled()
+        assert len(registry) == 1
+
+        assert any(
+            "wait_all: 1 task(s) did not finish within timeout=0.1s" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+        # 後片付け
         task.cancel()
         try:
             await task

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -60,6 +60,23 @@ class TestTaskRegistryRegister:
         await asyncio.sleep(0)
         assert len(registry) == 0
 
+    @pytest.mark.asyncio
+    async def test_register_task_with_return_value(self) -> None:
+        """Any 型のタスク（戻り値あり）を register できる。"""
+        registry = TaskRegistry()
+
+        async def returns_bool() -> bool:
+            return True
+
+        # asyncio.Task[bool] は asyncio.Task[Any] に適合するはず
+        task = asyncio.create_task(returns_bool())
+        registry.register(task)
+        assert len(registry) == 1
+
+        await task
+        await asyncio.sleep(0)
+        assert len(registry) == 0
+
 
 class TestTaskRegistryDoneCallback:
     """done_callback のエラーハンドリングテスト。"""
@@ -158,3 +175,39 @@ class TestTaskRegistryCancelAll:
         # タイムアウト 0.5s で cancel_all
         await registry.cancel_all(timeout=0.5)
         # cancel_all がハングせずに戻ることを確認
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_logs_warning_on_timeout(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """キャンセルが間に合わないタスクがある場合、警告ログを出力する。"""
+        registry = TaskRegistry()
+
+        async def stubborn() -> None:
+            try:
+                await asyncio.sleep(100)
+            except asyncio.CancelledError:
+                # キャンセルされても無視して長くスリープ
+                await asyncio.sleep(1.0)
+
+        task = asyncio.create_task(stubborn(), name="StubbornTask")
+        registry.register(task)
+
+        # タスクを開始させる
+        await asyncio.sleep(0)
+
+        # タイムアウト 0.1s で cancel_all
+        await registry.cancel_all(timeout=0.1)
+
+        assert any(
+            "StubbornTask" in record.message and "terminate within 0.1 seconds" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+        # 後片付け（テストが終わった後にタスクが残らないようにする）
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -1,0 +1,160 @@
+"""TaskRegistry のユニットテスト。"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from context_store.ingestion.task_registry import TaskRegistry
+
+
+class TestTaskRegistryRegister:
+    """TaskRegistry.register() のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_register_adds_task_and_removes_on_completion(self) -> None:
+        """register() でタスクが追加され、完了後に done_callback で除去される。"""
+        registry = TaskRegistry()
+
+        async def noop() -> None:
+            pass
+
+        task = asyncio.create_task(noop())
+        registry.register(task)
+        assert len(registry) == 1
+
+        # タスク完了を待機
+        await task
+        # done_callback はイベントループの次のサイクルで呼ばれる
+        await asyncio.sleep(0)
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_register_multiple_tasks(self) -> None:
+        """複数タスクを register し、それぞれが独立して除去される。"""
+        registry = TaskRegistry()
+        event = asyncio.Event()
+
+        async def wait_for_event() -> None:
+            await event.wait()
+
+        async def instant() -> None:
+            pass
+
+        task1 = asyncio.create_task(wait_for_event())
+        task2 = asyncio.create_task(instant())
+        registry.register(task1)
+        registry.register(task2)
+        assert len(registry) == 2
+
+        # task2 は即完了
+        await task2
+        await asyncio.sleep(0)
+        assert len(registry) == 1
+
+        # task1 も完了させる
+        event.set()
+        await task1
+        await asyncio.sleep(0)
+        assert len(registry) == 0
+
+
+class TestTaskRegistryDoneCallback:
+    """done_callback のエラーハンドリングテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_done_callback_logs_exception(self, caplog: pytest.LogCaptureFixture) -> None:
+        """未処理例外のあるタスクは logger.error() で記録される。"""
+        registry = TaskRegistry()
+
+        async def raise_error() -> None:
+            raise RuntimeError("test error")
+
+        task = asyncio.create_task(raise_error())
+        registry.register(task)
+
+        # タスク完了を待機（例外はコールバックでキャッチ）
+        with pytest.raises(RuntimeError):
+            await task
+        await asyncio.sleep(0)
+
+        assert len(registry) == 0
+        assert any("test error" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_done_callback_logs_cancellation(self, caplog: pytest.LogCaptureFixture) -> None:
+        """キャンセルされたタスクは logger.debug() で記録される。"""
+        caplog.set_level(logging.DEBUG, logger="context_store.ingestion.task_registry")
+        registry = TaskRegistry()
+
+        async def long_running() -> None:
+            await asyncio.sleep(100)
+
+        task = asyncio.create_task(long_running())
+        registry.register(task)
+        assert len(registry) == 1
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+
+        assert len(registry) == 0
+        assert any(
+            "cancelled" in record.message.lower()
+            for record in caplog.records
+            if record.levelno == logging.DEBUG
+        )
+
+
+class TestTaskRegistryCancelAll:
+    """TaskRegistry.cancel_all() のテスト。"""
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_cancels_running_tasks(self) -> None:
+        """cancel_all() は全タスクをキャンセルする。"""
+        registry = TaskRegistry()
+
+        async def long_running() -> None:
+            await asyncio.sleep(100)
+
+        task1 = asyncio.create_task(long_running())
+        task2 = asyncio.create_task(long_running())
+        registry.register(task1)
+        registry.register(task2)
+        assert len(registry) == 2
+
+        await registry.cancel_all(timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert task1.cancelled()
+        assert task2.cancelled()
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_with_empty_registry(self) -> None:
+        """空のレジストリで cancel_all() はエラーなく完了する。"""
+        registry = TaskRegistry()
+        await registry.cancel_all(timeout=1.0)
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_timeout_handles_stubborn_task(self) -> None:
+        """タイムアウト内にキャンセルできないタスクがあっても cancel_all() はハングしない。"""
+        registry = TaskRegistry()
+
+        async def stubborn() -> None:
+            try:
+                await asyncio.sleep(100)
+            except asyncio.CancelledError:
+                # キャンセルを無視してスリープ（ただしタイムアウト以内に終わる）
+                await asyncio.sleep(0.1)
+
+        task = asyncio.create_task(stubborn())
+        registry.register(task)
+
+        # タイムアウト 0.5s で cancel_all
+        await registry.cancel_all(timeout=0.5)
+        # cancel_all がハングせずに戻ることを確認

--- a/tests/unit/test_task_registry.py
+++ b/tests/unit/test_task_registry.py
@@ -84,6 +84,7 @@ class TestTaskRegistryDoneCallback:
     @pytest.mark.asyncio
     async def test_done_callback_logs_exception(self, caplog: pytest.LogCaptureFixture) -> None:
         """未処理例外のあるタスクは logger.error() で記録される。"""
+        caplog.set_level(logging.ERROR, logger="context_store.ingestion.task_registry")
         registry = TaskRegistry()
 
         async def raise_error() -> None:
@@ -92,7 +93,7 @@ class TestTaskRegistryDoneCallback:
         task = asyncio.create_task(raise_error())
         registry.register(task)
 
-        # タスク完了を待機（例外はコールバックでキャッチ）
+        # タスク完了を待機 (例外はコールバックでキャッチ)
         with pytest.raises(RuntimeError):
             await task
         await asyncio.sleep(0)
@@ -166,15 +167,24 @@ class TestTaskRegistryCancelAll:
             try:
                 await asyncio.sleep(100)
             except asyncio.CancelledError:
-                # キャンセルを無視してスリープ（ただしタイムアウト以内に終わる）
+                # キャンセルを無視してスリープ (ただしタイムアウト以内に終わる)
                 await asyncio.sleep(0.1)
 
         task = asyncio.create_task(stubborn())
         registry.register(task)
 
+        # タスクを開始させる
+        await asyncio.sleep(0)
+
         # タイムアウト 0.5s で cancel_all
         await registry.cancel_all(timeout=0.5)
         # cancel_all がハングせずに戻ることを確認
+
+        await asyncio.sleep(0)
+        # stubborn タスクは CancelledError を握り潰して正常終了する（cancelled ではない）
+        assert task.done()
+        assert not task.cancelled()
+        assert len(registry) == 0
 
     @pytest.mark.asyncio
     async def test_cancel_all_logs_warning_on_timeout(
@@ -200,7 +210,8 @@ class TestTaskRegistryCancelAll:
         await registry.cancel_all(timeout=0.1)
 
         assert any(
-            "StubbornTask" in record.message and "terminate within 0.1 seconds" in record.message
+            "StubbornTask" in record.message
+            and "did not finish within timeout=0.1s" in record.message
             for record in caplog.records
             if record.levelno == logging.WARNING
         )


### PR DESCRIPTION
## Summary
- TaskRegistry クラスを追加 — バックグラウンド asyncio.Task のライフサイクル管理
- graceful shutdown 時の一括キャンセルを提供
- ユニットテストを追加

## Test Plan
- [ ] `pytest tests/unit/test_task_registry.py -v` がパスすること