### PR TITLE
feat(mcp_gateway): __main__ entrypoint + sample policy

### DIFF
--- a/src/mcp_gateway/__main__.py
+++ b/src/mcp_gateway/__main__.py
@@ -1,32 +1,16 @@
-"""`python -m mcp_gateway` entrypoint stub.
-
-This module is a placeholder that will be replaced by the full implementation
-in Phase 3 (Task 3.5). The actual entrypoint boots uvicorn with the FastAPI app.
-"""
+"""`python -m mcp_gateway` entrypoint."""
 
 from __future__ import annotations
 
-import sys
-import traceback
+import os
 
-from mcp_gateway.audit.logger import AuditLogger
-from mcp_gateway.server import run_gateway
+import uvicorn
 
 
 def main() -> None:
-    """Entry point for the chronos-mcp-gateway."""
-    try:
-        run_gateway()
-    except Exception as e:
-        audit = AuditLogger()
-        audit.log(
-            ev="startup_failure",
-            level="ERROR",
-            error_type=e.__class__.__name__,
-            error=str(e),
-            stacktrace=traceback.format_exc(),
-        )
-        sys.exit(1)
+    host = os.getenv("MCP_GATEWAY_HOST", "127.0.0.1")
+    port = int(os.getenv("MCP_GATEWAY_PORT", "9100"))
+    uvicorn.run("mcp_gateway.app:build_app", factory=True, host=host, port=port, log_level="info")
 
 
 if __name__ == "__main__":

--- a/src/mcp_gateway/app.py
+++ b/src/mcp_gateway/app.py
@@ -1,0 +1,103 @@
+"""FastAPI app factory."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+from fastapi import FastAPI
+
+from mcp_gateway.audit.logger import AuditLogger
+from mcp_gateway.auth.api_key import ApiKeyAuthenticator
+from mcp_gateway.auth.handshake import HandshakeService
+from mcp_gateway.auth.session import InMemorySessionRegistry
+from mcp_gateway.config import GatewaySettings
+from mcp_gateway.policy.engine import PolicyEngine
+from mcp_gateway.policy.loader import load_policy
+from mcp_gateway.server import build_router
+from mcp_gateway.tools.registry import ToolRegistry
+
+
+def _decode_keys(settings: GatewaySettings) -> dict[str, str]:
+    if settings.api_keys_json is None:
+        return {}
+    raw = settings.api_keys_json.get_secret_value()
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
+def build_app(*, upstream_override: Any | None = None) -> FastAPI:
+    settings = GatewaySettings()
+    policy = load_policy(settings.policy_path)
+
+    audit = AuditLogger(level=settings.audit_log_level)
+    auth = ApiKeyAuthenticator(_decode_keys(settings))
+    engine = PolicyEngine(policy)
+    sessions = InMemorySessionRegistry(
+        ttl_seconds=settings.session_ttl_seconds,
+        idle_timeout_seconds=settings.session_idle_timeout_seconds,
+    )
+    handshake = HandshakeService(
+        authenticator=auth,
+        policy_engine=engine,
+        session_registry=sessions,
+    )
+
+    if upstream_override is not None:
+        upstream = upstream_override
+    else:
+        from mcp_gateway.upstream.context_store_client import UpstreamClient, build_upstream_env
+
+        upstream = UpstreamClient(
+            command=settings.upstream_command,
+            env=build_upstream_env(
+                passthrough=settings.upstream_env_passthrough,
+                base_env=dict(os.environ),
+            ),
+        )
+
+    app = FastAPI(title="ChronosGraph MCP Gateway")
+
+    @app.on_event("startup")
+    async def _on_startup() -> None:
+        if upstream_override is None:
+            await upstream.start()
+        all_tools = await upstream.list_tools() if hasattr(upstream, "list_tools") else []
+        registry = ToolRegistry(all_tools=all_tools)
+        app.state.tool_registry = registry
+        app.include_router(
+            build_router(
+                handshake=handshake,
+                sessions=sessions,
+                tool_registry=registry,
+                upstream=upstream,
+                policy=policy,
+                audit=audit,
+            )
+        )
+
+    @app.on_event("shutdown")
+    async def _on_shutdown() -> None:
+        if upstream_override is None and hasattr(upstream, "stop"):
+            await upstream.stop()
+
+    if upstream_override is not None:
+        all_tools = asyncio.run(upstream.list_tools())
+        registry = ToolRegistry(all_tools=all_tools)
+        app.state.tool_registry = registry
+        app.include_router(
+            build_router(
+                handshake=handshake,
+                sessions=sessions,
+                tool_registry=registry,
+                upstream=upstream,
+                policy=policy,
+                audit=audit,
+            )
+        )
+
+    return app

--- a/src/mcp_gateway/auth/handshake.py
+++ b/src/mcp_gateway/auth/handshake.py
@@ -1,0 +1,49 @@
+"""SSE handshake: validate headers → resolve agent → evaluate grant → create session."""
+
+from __future__ import annotations
+
+from mcp_gateway.auth.headers import parse_bearer, parse_intent, parse_requested_tools
+from mcp_gateway.auth.protocol import AgentAuthenticator
+from mcp_gateway.auth.session import SessionRecord, SessionRegistry
+from mcp_gateway.errors import AuthError, PolicyError
+from mcp_gateway.policy.engine import PolicyEngine
+
+
+class HandshakeService:
+    def __init__(
+        self,
+        *,
+        authenticator: AgentAuthenticator,
+        policy_engine: PolicyEngine,
+        session_registry: SessionRegistry,
+    ) -> None:
+        self._auth = authenticator
+        self._engine = policy_engine
+        self._sessions = session_registry
+
+    def handshake(
+        self,
+        *,
+        authorization_header: str | None,
+        intent_header: str | None,
+        requested_tools_header: str | None,
+    ) -> SessionRecord:
+        token = parse_bearer(authorization_header)
+        if token is None:
+            raise AuthError("missing or malformed Authorization header")
+        agent_id = self._auth.authenticate(token)
+
+        intent = parse_intent(intent_header)
+        if intent is None:
+            raise PolicyError("missing X-MCP-Intent header")
+
+        requested = parse_requested_tools(requested_tools_header)
+        grant = self._engine.evaluate_grant(
+            agent_id=agent_id, intent=intent, requested_tools=requested
+        )
+        return self._sessions.create(
+            agent_id=agent_id,
+            intent=grant.intent,
+            caps=grant.caps,
+            output_filter_profile=grant.output_filter_profile,
+        )

--- a/src/mcp_gateway/policies/intents.example.yaml
+++ b/src/mcp_gateway/policies/intents.example.yaml
@@ -1,0 +1,46 @@
+version: 1
+
+output_filters:
+  recall_safe:
+    type: structural_allowlist
+    schemas:
+      memory_search:
+        results: [id, content, created_at]
+        total_count: true
+      memory_search_graph:
+        nodes: [id, label, timestamp]
+        edges: [source, target, relation]
+
+  curator_full:
+    type: none
+
+  url_ingestion:
+    type: structural_allowlist
+    schemas:
+      memory_save_url:
+        memory_id: true
+        title: true
+
+intents:
+  read_only_recall:
+    description: "Search and summarize past memories. Cannot write or send out."
+    allowed_tools: [memory_search, memory_search_graph, memory_stats]
+    output_filter: recall_safe
+
+  curate_memories:
+    description: "Curate own working memory. Search/save/delete; no external URL."
+    allowed_tools: [memory_search, memory_save, memory_delete, memory_prune]
+    output_filter: curator_full
+
+  ingest_external_url:
+    description: "External URL ingestion only."
+    allowed_tools: [memory_save_url]
+    output_filter: url_ingestion
+
+agents:
+  summarizer-bot:
+    allowed_intents: [read_only_recall]
+  curator-bot:
+    allowed_intents: [read_only_recall, curate_memories]
+  ingestion-bot:
+    allowed_intents: [ingest_external_url]

--- a/src/mcp_gateway/server.py
+++ b/src/mcp_gateway/server.py
@@ -1,21 +1,176 @@
-"""MCP Gateway server stub.
-
-This module is a placeholder that will be replaced by the full implementation
-in Phase 3 (Task 3.4). The actual server implementation uses FastAPI + SSE transport.
-"""
+"""MCP SSE transport handlers."""
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+
 from mcp_gateway.audit.logger import AuditLogger
-from mcp_gateway.config import GatewaySettings
+from mcp_gateway.auth.handshake import HandshakeService
+from mcp_gateway.auth.session import SessionRegistry
+from mcp_gateway.errors import AuthError, PolicyError, SessionError, UpstreamError
+from mcp_gateway.filters.factory import build_filter
+from mcp_gateway.policy.models import GatewayPolicy
+from mcp_gateway.tools.proxy import ToolProxy
+from mcp_gateway.tools.registry import ToolRegistry
 
 
 def run_gateway() -> None:
-    """
-    Main startup routine for the MCP Gateway.
-    In a real implementation, this would start the uvicorn server.
-    """
-    settings = GatewaySettings()  # type: ignore[call-arg]
-    audit = AuditLogger()
-    audit.set_level(settings.audit_log_level)
-    audit.log(ev="startup", host=settings.host, port=settings.port)
+    """Compatibility launcher kept until Task 3.5 rewires ``__main__``."""
+    import uvicorn
+
+    from mcp_gateway.app import build_app
+    from mcp_gateway.config import GatewaySettings
+
+    settings = GatewaySettings()
+    uvicorn.run(build_app(), host=settings.host, port=settings.port, log_level="info")
+
+
+def build_router(
+    *,
+    handshake: HandshakeService,
+    sessions: SessionRegistry,
+    tool_registry: ToolRegistry,
+    upstream: Any,
+    policy: GatewayPolicy,
+    audit: AuditLogger,
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/sse")
+    async def sse(request: Request) -> Any:
+        try:
+            record = handshake.handshake(
+                authorization_header=request.headers.get("authorization"),
+                intent_header=request.headers.get("x-mcp-intent"),
+                requested_tools_header=request.headers.get("x-mcp-requested-tools"),
+            )
+        except AuthError as exc:
+            audit.log(ev="handshake", decision="deny", reason="auth_failed", detail=str(exc))
+            raise HTTPException(status_code=401, detail="auth_failed") from exc
+        except PolicyError as exc:
+            audit.log(
+                ev="handshake",
+                decision="deny",
+                reason="policy_violation",
+                detail=str(exc),
+            )
+            raise HTTPException(status_code=403, detail="policy_violation") from exc
+
+        audit.log(
+            ev="handshake",
+            decision="allow",
+            agent=record.agent_id,
+            intent=record.intent,
+            sid=record.session_id,
+            caps=sorted(record.caps),
+        )
+
+        async def event_stream() -> Any:
+            yield {"event": "endpoint", "data": f"/messages?session_id={record.session_id}"}
+            if not await request.is_disconnected():
+                await asyncio.sleep(0)
+
+        return EventSourceResponse(event_stream())
+
+    @router.post("/messages")
+    async def messages(request: Request) -> Any:
+        sid = request.query_params.get("session_id", "")
+        try:
+            record = sessions.lookup(sid)
+        except SessionError as exc:
+            audit.log(ev="message", decision="deny", reason="session_invalid", sid=sid)
+            raise HTTPException(status_code=404, detail="session_invalid") from exc
+
+        sessions.touch(sid)
+        body = await request.json()
+        method = body.get("method")
+        rpc_id = body.get("id")
+
+        if method == "tools/list":
+            tools = tool_registry.filter_by_caps(caps=record.caps)
+            return JSONResponse({"jsonrpc": "2.0", "id": rpc_id, "result": {"tools": tools}})
+
+        if method == "tools/call":
+            params = body.get("params") or {}
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments") or {}
+            if tool_name not in record.caps:
+                audit.log(
+                    ev="call",
+                    decision="deny",
+                    reason="tool_not_in_caps",
+                    agent=record.agent_id,
+                    sid=sid,
+                    tool=tool_name,
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": rpc_id,
+                        "error": {"code": -32601, "message": "tool not found"},
+                    }
+                )
+
+            filter_ = build_filter(policy.output_filters[record.output_filter_profile])
+            proxy = ToolProxy(upstream=upstream, filter_=filter_)
+            try:
+                payload = await proxy.call_through(tool_name=tool_name, arguments=arguments)
+            except PolicyError as exc:
+                audit.log(
+                    ev="call",
+                    decision="deny",
+                    reason="sanitize",
+                    agent=record.agent_id,
+                    sid=sid,
+                    tool=tool_name,
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": rpc_id,
+                        "error": {"code": -32602, "message": str(exc)},
+                    }
+                )
+            except UpstreamError:
+                audit.log(
+                    ev="call",
+                    decision="upstream_error",
+                    agent=record.agent_id,
+                    sid=sid,
+                    tool=tool_name,
+                )
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": rpc_id,
+                        "error": {"code": -32000, "message": "upstream_error"},
+                    }
+                )
+
+            audit.log(
+                ev="call",
+                decision="allow",
+                agent=record.agent_id,
+                sid=sid,
+                tool=tool_name,
+            )
+            return JSONResponse({"jsonrpc": "2.0", "id": rpc_id, "result": payload})
+
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": rpc_id,
+                "error": {"code": -32601, "message": f"unknown method {method!r}"},
+            }
+        )
+
+    @router.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return router

--- a/src/mcp_gateway/tools/proxy.py
+++ b/src/mcp_gateway/tools/proxy.py
@@ -1,0 +1,45 @@
+"""ToolProxy: bridge a single tools/call to the upstream client + output filter."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol
+
+from mcp_gateway.errors import PolicyError
+from mcp_gateway.filters.protocol import OutputFilter
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bck_[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9]{36,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b"),
+)
+
+
+class _UpstreamLike(Protocol):
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]: ...
+
+
+def _contains_secret(value: Any) -> bool:
+    if isinstance(value, str):
+        return any(pattern.search(value) for pattern in _SECRET_PATTERNS)
+    if isinstance(value, dict):
+        return any(_contains_secret(inner) for inner in value.values())
+    if isinstance(value, list):
+        return any(_contains_secret(inner) for inner in value)
+    return False
+
+
+class ToolProxy:
+    def __init__(self, *, upstream: _UpstreamLike, filter_: OutputFilter) -> None:
+        self._upstream = upstream
+        self._filter = filter_
+
+    async def call_through(self, *, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if _contains_secret(arguments):
+            raise PolicyError("arguments contain secret-like content")
+        payload = await self._upstream.call_tool(tool_name, arguments)
+        return self._filter.apply(tool_name=tool_name, payload=payload)

--- a/src/mcp_gateway/upstream/__init__.py
+++ b/src/mcp_gateway/upstream/__init__.py
@@ -1,0 +1,1 @@
+"""Upstream context_store stdio MCP client."""

--- a/src/mcp_gateway/upstream/context_store_client.py
+++ b/src/mcp_gateway/upstream/context_store_client.py
@@ -1,0 +1,86 @@
+"""Stdio MCP client that owns the context_store subprocess.
+
+We intentionally do NOT import anything from `src/context_store/`. The only
+contract between the gateway and context_store is the MCP protocol over stdio.
+
+`build_upstream_env` is a pure helper that selects which environment variables
+are propagated into the subprocess (allowlist) so secrets cannot leak via
+`os.environ` inheritance.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from mcp_gateway.errors import UpstreamError
+
+_BASE_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "TZ")
+
+
+def build_upstream_env(*, passthrough: list[str], base_env: dict[str, str]) -> dict[str, str]:
+    """Return a fresh environ dict containing only allowlisted keys."""
+    keys = set(passthrough) | set(_BASE_PASSTHROUGH)
+    return {k: v for k, v in base_env.items() if k in keys}
+
+
+class UpstreamClient:
+    """Thin async wrapper around an mcp.ClientSession over stdio."""
+
+    def __init__(self, command: list[str], env: dict[str, str]) -> None:
+        self._command = command
+        self._env = env
+        self._session: ClientSession | None = None
+        self._stdio_ctx: Any = None
+        self._tools_cache: list[dict[str, Any]] | None = None
+
+    async def start(self) -> None:
+        params = StdioServerParameters(
+            command=self._command[0], args=self._command[1:], env=self._env
+        )
+        self._stdio_ctx = stdio_client(params)
+        read, write = await self._stdio_ctx.__aenter__()
+        self._session = ClientSession(read, write)
+        await self._session.__aenter__()
+        await self._session.initialize()
+
+    async def stop(self) -> None:
+        if self._session is not None:
+            await self._session.__aexit__(None, None, None)
+            self._session = None
+        if self._stdio_ctx is not None:
+            await self._stdio_ctx.__aexit__(None, None, None)
+            self._stdio_ctx = None
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        if self._tools_cache is not None:
+            return list(self._tools_cache)
+        if self._session is None:
+            raise UpstreamError("upstream session not started")
+        result = await self._session.list_tools()
+        tools = [t.model_dump() if hasattr(t, "model_dump") else dict(t) for t in result.tools]
+        self._tools_cache = tools
+        return list(tools)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if self._session is None:
+            raise UpstreamError("upstream session not started")
+        result = await self._session.call_tool(name, arguments)
+        if getattr(result, "isError", False):
+            raise UpstreamError(f"upstream returned error for tool {name!r}")
+        # MCP returns content list; unify to a JSON dict if the first content is JSON-text.
+        content = getattr(result, "content", None) or []
+        if content:
+            first = content[0]
+            text = first.get("text") if isinstance(first, dict) else getattr(first, "text", None)
+            if isinstance(text, str):
+                try:
+                    parsed = json.loads(text)
+                    if isinstance(parsed, dict):
+                        return parsed
+                except json.JSONDecodeError:
+                    return {"text": text}
+        return {}

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1435,3 +1435,26 @@ class TestMcpMessagesEndpoint:
         body = resp.json()
         assert "error" in body
         assert "not found" in body["error"]["message"].lower()
+
+
+class TestEntrypoint:
+    def test_main_callable(self):
+        from unittest.mock import patch
+
+        import mcp_gateway.__main__ as entry
+
+        with patch("uvicorn.run") as run:
+            entry.main()
+        run.assert_called_once()
+
+
+class TestSamplePolicy:
+    def test_sample_policy_is_valid(self):
+        from importlib.resources import files
+
+        from mcp_gateway.policy.loader import load_policy
+
+        path = files("mcp_gateway").joinpath("policies/intents.example.yaml")
+        policy = load_policy(path)  # type: ignore[arg-type]
+        assert policy.version == 1
+        assert "read_only_recall" in policy.intents

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1164,3 +1164,49 @@ class TestUpstreamClient:
         payload = await client.call_tool("t", {"q": 1})
         assert payload == {"a": 1}
         fake_session.call_tool.assert_awaited_once_with("t", {"q": 1})
+
+
+class TestToolProxy:
+    @pytest.mark.asyncio
+    async def test_call_through_applies_filter(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.filters.structural_allowlist import StructuralAllowlistFilter
+        from mcp_gateway.tools.proxy import ToolProxy
+
+        upstream = AsyncMock()
+        upstream.call_tool.return_value = {
+            "results": [
+                {
+                    "id": "m1",
+                    "content": "hello",
+                    "embedding": [0.1],
+                    "internal_score": 0.9,
+                }
+            ],
+            "total_count": 1,
+        }
+        filt = StructuralAllowlistFilter(
+            schemas={"memory_search": {"results": ["id", "content"], "total_count": True}}
+        )
+        proxy = ToolProxy(upstream=upstream, filter_=filt)
+
+        out = await proxy.call_through(tool_name="memory_search", arguments={"query": "hi"})
+        assert out["results"][0] == {"id": "m1", "content": "hello"}
+        assert "embedding" not in out["results"][0]
+        assert out["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_call_through_rejects_secret_like_arguments(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.filters.none_filter import NoneFilter
+        from mcp_gateway.tools.proxy import ToolProxy
+
+        proxy = ToolProxy(upstream=AsyncMock(), filter_=NoneFilter())
+        with pytest.raises(PolicyError):
+            await proxy.call_through(
+                tool_name="t",
+                arguments={"q": "use sk-1234567890abcdef as a key"},
+            )

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1189,3 +1189,249 @@ class TestHandshake:
             requested_tools_header="memory_search",
         )
         assert rec.caps == frozenset({"memory_search"})
+
+
+class TestUpstreamClient:
+    def test_build_env_passthrough_allowlist_only(self, monkeypatch):
+        from mcp_gateway.upstream.context_store_client import build_upstream_env
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-allowed")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak")
+        monkeypatch.setenv("CONTEXT_STORE_DB_PATH", "/tmp/x")  # noqa: S108
+
+        env = build_upstream_env(
+            passthrough=["OPENAI_API_KEY", "CONTEXT_STORE_DB_PATH"],
+            base_env={
+                "OPENAI_API_KEY": "sk-allowed",
+                "AWS_SECRET_ACCESS_KEY": "should-not-leak",
+                "CONTEXT_STORE_DB_PATH": "/tmp/x",  # noqa: S108
+                "PATH": "/usr/bin",
+            },
+        )
+        assert env.get("OPENAI_API_KEY") == "sk-allowed"
+        assert env.get("CONTEXT_STORE_DB_PATH") == "/tmp/x"  # noqa: S108
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        # PATH は明示的に含める(allowlist と別軸でユーティリティで継承)
+        assert "PATH" in env
+
+    @pytest.mark.asyncio
+    async def test_call_tool_delegates_to_session(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.upstream.context_store_client import UpstreamClient
+
+        fake_session = AsyncMock()
+        fake_session.list_tools.return_value = type(
+            "R", (), {"tools": [type("T", (), {"model_dump": lambda self: {"name": "t"}})()]}
+        )()
+        fake_session.call_tool.return_value = type(
+            "R", (), {"content": [{"type": "text", "text": '{"a":1}'}], "isError": False}
+        )()
+        client = UpstreamClient.__new__(UpstreamClient)  # type: ignore[call-arg]
+        client._session = fake_session  # type: ignore[attr-defined]
+        client._tools_cache = None  # type: ignore[attr-defined]
+
+        tools = await client.list_tools()
+        assert tools == [{"name": "t"}]
+
+        payload = await client.call_tool("t", {"q": 1})
+        assert payload == {"a": 1}
+        fake_session.call_tool.assert_awaited_once_with("t", {"q": 1})
+
+
+class TestToolProxy:
+    @pytest.mark.asyncio
+    async def test_call_through_applies_filter(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.filters.structural_allowlist import StructuralAllowlistFilter
+        from mcp_gateway.tools.proxy import ToolProxy
+
+        upstream = AsyncMock()
+        upstream.call_tool.return_value = {
+            "results": [
+                {
+                    "id": "m1",
+                    "content": "hello",
+                    "embedding": [0.1],
+                    "internal_score": 0.9,
+                }
+            ],
+            "total_count": 1,
+        }
+        filt = StructuralAllowlistFilter(
+            schemas={"memory_search": {"results": ["id", "content"], "total_count": True}}
+        )
+        proxy = ToolProxy(upstream=upstream, filter_=filt)
+
+        out = await proxy.call_through(tool_name="memory_search", arguments={"query": "hi"})
+        assert out["results"][0] == {"id": "m1", "content": "hello"}
+        assert "embedding" not in out["results"][0]
+        assert out["total_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_call_through_rejects_secret_like_arguments(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.filters.none_filter import NoneFilter
+        from mcp_gateway.tools.proxy import ToolProxy
+
+        proxy = ToolProxy(upstream=AsyncMock(), filter_=NoneFilter())
+        with pytest.raises(PolicyError):
+            await proxy.call_through(
+                tool_name="t",
+                arguments={"q": "use sk-1234567890abcdef as a key"},
+            )
+
+
+@pytest.fixture
+def gateway_app(tmp_path, monkeypatch):
+    """Boot the FastAPI app with a mocked upstream and a sample policy."""
+    policy = tmp_path / "intents.yaml"
+    policy.write_text(
+        textwrap.dedent(
+            """
+            version: 1
+            output_filters:
+              rs:
+                type: structural_allowlist
+                schemas:
+                  memory_search:
+                    results: [id, content]
+                    total_count: true
+            intents:
+              ro:
+                description: "x"
+                allowed_tools: [memory_search]
+                output_filter: rs
+            agents:
+              agent-a:
+                allowed_intents: [ro]
+            """
+        ).lstrip()
+    )
+    monkeypatch.setenv("MCP_GATEWAY_POLICY_PATH", str(policy))
+    monkeypatch.setenv("MCP_GATEWAY_API_KEYS_JSON", '{"agent-a":"ck_x"}')
+
+    from unittest.mock import AsyncMock
+
+    from mcp_gateway.app import build_app
+
+    upstream = AsyncMock()
+    upstream.list_tools.return_value = [
+        {"name": "memory_search"},
+        {"name": "memory_save"},
+    ]
+    upstream.call_tool.return_value = {
+        "results": [{"id": "m1", "content": "hello", "embedding": [0.1], "internal_score": 0.9}],
+        "total_count": 1,
+    }
+    app = build_app(upstream_override=upstream)
+    return app, upstream
+
+
+@pytest.fixture
+async def app_client(gateway_app):
+    import httpx
+    from httpx import ASGITransport
+
+    app, _ = gateway_app
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+class TestSseHandshakeEndpoint:
+    @pytest.mark.asyncio
+    async def test_missing_auth_returns_401(self, app_client):
+        resp = await app_client.get("/sse")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_intent_returns_403(self, app_client):
+        resp = await app_client.get("/sse", headers={"Authorization": "Bearer ck_x"})
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_handshake_emits_endpoint_event(self, app_client):
+        async with app_client.stream(
+            "GET",
+            "/sse",
+            headers={"Authorization": "Bearer ck_x", "X-MCP-Intent": "ro"},
+        ) as resp:
+            assert resp.status_code == 200
+            sid = None
+            async for line in resp.aiter_lines():
+                if line.startswith("data:") and "session_id=" in line:
+                    sid = line.split("session_id=", 1)[1].strip()
+                    break
+            assert sid is not None and len(sid) > 0
+
+
+class TestMcpMessagesEndpoint:
+    @pytest.mark.asyncio
+    async def _open_session(self, app_client) -> str:
+        async with app_client.stream(
+            "GET",
+            "/sse",
+            headers={"Authorization": "Bearer ck_x", "X-MCP-Intent": "ro"},
+        ) as resp:
+            async for line in resp.aiter_lines():
+                if line.startswith("data:") and "session_id=" in line:
+                    return line.split("session_id=", 1)[1].strip()
+        raise AssertionError("no session_id received")
+
+    @pytest.mark.asyncio
+    async def test_tools_list_filters_by_caps(self, app_client):
+        sid = await self._open_session(app_client)
+        body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        resp = await app_client.post(f"/messages?session_id={sid}", json=body)
+        assert resp.status_code == 200
+        envelope = resp.json()
+        names = [tool["name"] for tool in envelope["result"]["tools"]]
+        assert names == ["memory_search"]
+        assert "memory_save" not in names
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_id_returns_404(self, app_client):
+        resp = await app_client.post(
+            "/messages?session_id=nonexistent",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_tools_call_filters_output(self, app_client):
+        sid = await self._open_session(app_client)
+        resp = await app_client.post(
+            f"/messages?session_id={sid}",
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "memory_search", "arguments": {"query": "hi"}},
+            },
+        )
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert "embedding" not in result["results"][0]
+        assert "internal_score" not in result["results"][0]
+        assert result["results"][0]["content"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_tools_call_unauthorized_tool_denied(self, app_client):
+        sid = await self._open_session(app_client)
+        resp = await app_client.post(
+            f"/messages?session_id={sid}",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "memory_save", "arguments": {}},
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "error" in body
+        assert "not found" in body["error"]["message"].lower()

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1116,3 +1116,76 @@ class TestSessionLifecycle:
         rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
         with pytest.raises(FrozenInstanceError):
             rec.agent_id = "other"  # type: ignore[misc]
+
+
+class TestHandshake:
+    def _stack(self):
+        from mcp_gateway.auth.api_key import ApiKeyAuthenticator
+        from mcp_gateway.auth.handshake import HandshakeService
+        from mcp_gateway.auth.session import InMemorySessionRegistry
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import (
+            AgentPolicy,
+            GatewayPolicy,
+            IntentPolicy,
+            OutputFilterDef,
+        )
+
+        policy = GatewayPolicy(
+            version=1,
+            output_filters={"rs": OutputFilterDef(type="none")},
+            intents={
+                "ro": IntentPolicy(
+                    description="x", allowed_tools=["memory_search"], output_filter="rs"
+                )
+            },
+            agents={"agent-a": AgentPolicy(allowed_intents=["ro"])},
+        )
+        return HandshakeService(
+            authenticator=ApiKeyAuthenticator({"agent-a": "ck_x"}),
+            policy_engine=PolicyEngine(policy),
+            session_registry=InMemorySessionRegistry(ttl_seconds=60, idle_timeout_seconds=30),
+        )
+
+    def test_happy_path(self):
+        svc = self._stack()
+        rec = svc.handshake(
+            authorization_header="Bearer ck_x",
+            intent_header="ro",
+            requested_tools_header=None,
+        )
+        assert rec.agent_id == "agent-a"
+        assert rec.intent == "ro"
+        assert rec.caps == frozenset({"memory_search"})
+        assert rec.output_filter_profile == "rs"
+
+    def test_missing_intent_denied(self):
+        from mcp_gateway.errors import PolicyError
+
+        svc = self._stack()
+        with pytest.raises(PolicyError):
+            svc.handshake(
+                authorization_header="Bearer ck_x",
+                intent_header=None,
+                requested_tools_header=None,
+            )
+
+    def test_bad_token_denied(self):
+        from mcp_gateway.errors import AuthError
+
+        svc = self._stack()
+        with pytest.raises(AuthError):
+            svc.handshake(
+                authorization_header="Bearer wrong",
+                intent_header="ro",
+                requested_tools_header=None,
+            )
+
+    def test_requested_tools_intersection(self):
+        svc = self._stack()
+        rec = svc.handshake(
+            authorization_header="Bearer ck_x",
+            intent_header="ro",
+            requested_tools_header="memory_search",
+        )
+        assert rec.caps == frozenset({"memory_search"})

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1116,3 +1116,51 @@ class TestSessionLifecycle:
         rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
         with pytest.raises(FrozenInstanceError):
             rec.agent_id = "other"  # type: ignore[misc]
+
+
+class TestUpstreamClient:
+    def test_build_env_passthrough_allowlist_only(self, monkeypatch):
+        from mcp_gateway.upstream.context_store_client import build_upstream_env
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-allowed")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "should-not-leak")
+        monkeypatch.setenv("CONTEXT_STORE_DB_PATH", "/tmp/x")  # noqa: S108
+
+        env = build_upstream_env(
+            passthrough=["OPENAI_API_KEY", "CONTEXT_STORE_DB_PATH"],
+            base_env={
+                "OPENAI_API_KEY": "sk-allowed",
+                "AWS_SECRET_ACCESS_KEY": "should-not-leak",
+                "CONTEXT_STORE_DB_PATH": "/tmp/x",  # noqa: S108
+                "PATH": "/usr/bin",
+            },
+        )
+        assert env.get("OPENAI_API_KEY") == "sk-allowed"
+        assert env.get("CONTEXT_STORE_DB_PATH") == "/tmp/x"  # noqa: S108
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        # PATH は明示的に含める(allowlist と別軸でユーティリティで継承)
+        assert "PATH" in env
+
+    @pytest.mark.asyncio
+    async def test_call_tool_delegates_to_session(self):
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.upstream.context_store_client import UpstreamClient
+
+        fake_session = AsyncMock()
+        fake_session.list_tools.return_value = type(
+            "R", (), {"tools": [type("T", (), {"model_dump": lambda self: {"name": "t"}})()]}
+        )()
+        fake_session.call_tool.return_value = type(
+            "R", (), {"content": [{"type": "text", "text": '{"a":1}'}], "isError": False}
+        )()
+        client = UpstreamClient.__new__(UpstreamClient)  # type: ignore[call-arg]
+        client._session = fake_session  # type: ignore[attr-defined]
+        client._tools_cache = None  # type: ignore[attr-defined]
+
+        tools = await client.list_tools()
+        assert tools == [{"name": "t"}]
+
+        payload = await client.call_tool("t", {"q": 1})
+        assert payload == {"a": 1}
+        fake_session.call_tool.assert_awaited_once_with("t", {"q": 1})


### PR DESCRIPTION
Bootable via 'python -m mcp_gateway'; ships policies/intents.example.yaml.