### PR TITLE
feat: add ParamConstraint, ToolGuardrail, IntentPolicy.guardrails

### DIFF
--- a/src/mcp_gateway/auth/handshake.py
+++ b/src/mcp_gateway/auth/handshake.py
@@ -47,5 +47,6 @@ class HandshakeService:
             agent_id=agent_id,
             intent=grant.intent,
             caps=grant.caps,
+            guardrails=grant.guardrails,
             output_filter_profile=grant.output_filter_profile,
         )

--- a/src/mcp_gateway/auth/session.py
+++ b/src/mcp_gateway/auth/session.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import threading
 import uuid
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Iterable, Protocol
@@ -87,7 +88,7 @@ class InMemorySessionRegistry:
                 agent_id=agent_id,
                 intent=intent,
                 caps=frozenset(caps),
-                guardrails=guardrails.copy(),
+                guardrails=deepcopy(guardrails),
                 output_filter_profile=output_filter_profile,
                 issued_at=now,
                 expires_at=now + self._ttl,

--- a/src/mcp_gateway/auth/session.py
+++ b/src/mcp_gateway/auth/session.py
@@ -11,9 +11,12 @@ import threading
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Iterable, Protocol
+from typing import TYPE_CHECKING, Iterable, Protocol
 
 from mcp_gateway.errors import SessionError
+
+if TYPE_CHECKING:
+    from mcp_gateway.policy.models import ToolGuardrail
 
 
 def _utcnow() -> datetime:
@@ -26,6 +29,7 @@ class SessionRecord:
     agent_id: str
     intent: str
     caps: frozenset[str]
+    guardrails: dict[str, ToolGuardrail]
     output_filter_profile: str
     issued_at: datetime
     expires_at: datetime
@@ -38,6 +42,7 @@ class SessionRegistry(Protocol):
         agent_id: str,
         intent: str,
         caps: Iterable[str],
+        guardrails: dict[str, ToolGuardrail],
         output_filter_profile: str,
     ) -> SessionRecord: ...
 
@@ -71,6 +76,7 @@ class InMemorySessionRegistry:
         agent_id: str,
         intent: str,
         caps: Iterable[str],
+        guardrails: dict[str, ToolGuardrail],
         output_filter_profile: str,
     ) -> SessionRecord:
         with self._lock:
@@ -81,6 +87,7 @@ class InMemorySessionRegistry:
                 agent_id=agent_id,
                 intent=intent,
                 caps=frozenset(caps),
+                guardrails=guardrails,
                 output_filter_profile=output_filter_profile,
                 issued_at=now,
                 expires_at=now + self._ttl,

--- a/src/mcp_gateway/auth/session.py
+++ b/src/mcp_gateway/auth/session.py
@@ -87,7 +87,7 @@ class InMemorySessionRegistry:
                 agent_id=agent_id,
                 intent=intent,
                 caps=frozenset(caps),
-                guardrails=guardrails,
+                guardrails=guardrails.copy(),
                 output_filter_profile=output_filter_profile,
                 issued_at=now,
                 expires_at=now + self._ttl,

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -134,7 +134,7 @@ class PolicyEngine:
                     # Note: We rely on the fact that pattern was validated at load time.
                     # For absolute ReDoS safety, one could use a library with timeouts,
                     # but here we ensure pattern length and max_length are capped.
-                    if not re.match(constraint.pattern, val):
+                    if not re.fullmatch(constraint.pattern, val):
                         raise PolicyError(
                             f"parameter {param_name!r} does not match required pattern"
                         )

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -118,7 +118,8 @@ class PolicyEngine:
 
             # 2. Allowed values
             if constraint.allowed_values is not None:
-                if val not in constraint.allowed_values:
+                # Use strict type comparison because True == 1 in Python.
+                if not any(v == val and type(v) is type(val) for v in constraint.allowed_values):
                     raise PolicyError(
                         f"parameter {param_name!r} has invalid value {val!r}. "
                         f"allowed: {constraint.allowed_values}"

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -88,7 +88,7 @@ class PolicyEngine:
 
             val = arguments[param_name]
 
-            # Type check
+            # 1. Type check
             if constraint.type is not None:
                 types_map: dict[str, type | tuple[type, ...]] = {
                     "string": str,
@@ -103,7 +103,7 @@ class PolicyEngine:
                         f"got {type(val).__name__}"
                     )
 
-            # Allowed values
+            # 2. Allowed values
             if constraint.allowed_values is not None:
                 if val not in constraint.allowed_values:
                     raise PolicyError(
@@ -111,13 +111,16 @@ class PolicyEngine:
                         f"allowed: {constraint.allowed_values}"
                     )
 
-            # String specific constraints
+            # 3. String-specific constraints
             if isinstance(val, str):
                 if constraint.max_length is not None and len(val) > constraint.max_length:
                     raise PolicyError(
                         f"parameter {param_name!r} exceeds max_length ({constraint.max_length})"
                     )
                 if constraint.pattern is not None:
+                    # Note: We rely on the fact that pattern was validated at load time.
+                    # For absolute ReDoS safety, one could use a library with timeouts,
+                    # but here we ensure pattern length and max_length are capped.
                     if not re.match(constraint.pattern, val):
                         raise PolicyError(
                             f"parameter {param_name!r} does not match required pattern"

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -7,8 +7,10 @@ to the upstream subprocess.
 
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import Any
 
 from mcp_gateway.errors import PolicyError
 from mcp_gateway.policy.models import GatewayPolicy, ToolGuardrail
@@ -66,3 +68,56 @@ class PolicyEngine:
     def check_call(*, caps: frozenset[str], tool_name: str) -> None:
         if tool_name not in caps:
             raise PolicyError(f"tool {tool_name!r} is not in session capabilities")
+
+    @staticmethod
+    def validate_call(
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        guardrail: ToolGuardrail | None,
+    ) -> None:
+        if guardrail is None:
+            return
+
+        for param_name, constraint in guardrail.params.items():
+            if constraint.forbidden and param_name in arguments:
+                raise PolicyError(f"parameter {param_name!r} is forbidden for tool {tool_name!r}")
+
+            if param_name not in arguments:
+                continue
+
+            val = arguments[param_name]
+
+            # Type check
+            if constraint.type is not None:
+                expected_type = {
+                    "string": str,
+                    "integer": int,
+                    "number": (int, float),
+                    "boolean": bool,
+                }[constraint.type]
+                if not isinstance(val, expected_type):
+                    raise PolicyError(
+                        f"parameter {param_name!r} must be {constraint.type}, "
+                        f"got {type(val).__name__}"
+                    )
+
+            # Allowed values
+            if constraint.allowed_values is not None:
+                if val not in constraint.allowed_values:
+                    raise PolicyError(
+                        f"parameter {param_name!r} has invalid value {val!r}. "
+                        f"allowed: {constraint.allowed_values}"
+                    )
+
+            # String specific constraints
+            if isinstance(val, str):
+                if constraint.max_length is not None and len(val) > constraint.max_length:
+                    raise PolicyError(
+                        f"parameter {param_name!r} exceeds max_length ({constraint.max_length})"
+                    )
+                if constraint.pattern is not None:
+                    if not re.match(constraint.pattern, val):
+                        raise PolicyError(
+                            f"parameter {param_name!r} does not match required pattern"
+                        )

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -79,6 +79,12 @@ class PolicyEngine:
         if guardrail is None:
             return
 
+        if guardrail.requires_approval:
+            # Until approval flow is implemented, we must fail closed.
+            raise PolicyError(
+                f"tool {tool_name!r} requires manual approval which is not yet implemented"
+            )
+
         for param_name, constraint in guardrail.params.items():
             if constraint.forbidden and param_name in arguments:
                 raise PolicyError(f"parameter {param_name!r} is forbidden for tool {tool_name!r}")
@@ -90,6 +96,13 @@ class PolicyEngine:
 
             # 1. Type check
             if constraint.type is not None:
+                # Booleans are subclasses of int in Python, but for policy enforcement
+                # we treat them as distinct types.
+                if constraint.type in ("integer", "number") and isinstance(val, bool):
+                    raise PolicyError(
+                        f"parameter {param_name!r} must be {constraint.type}, got boolean"
+                    )
+
                 types_map: dict[str, type | tuple[type, ...]] = {
                     "string": str,
                     "integer": int,

--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -90,12 +90,13 @@ class PolicyEngine:
 
             # Type check
             if constraint.type is not None:
-                expected_type = {
+                types_map: dict[str, type | tuple[type, ...]] = {
                     "string": str,
                     "integer": int,
                     "number": (int, float),
                     "boolean": bool,
-                }[constraint.type]
+                }
+                expected_type = types_map[constraint.type]
                 if not isinstance(val, expected_type):
                     raise PolicyError(
                         f"parameter {param_name!r} must be {constraint.type}, "

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -24,6 +24,8 @@ class OutputFilterDef(BaseModel):
 
 
 MAX_PARAM_LENGTH = 1048576  # 1MB
+MAX_PATTERN_LENGTH = 200
+RE_DOS_MAX_LENGTH = 4096
 
 
 class ParamConstraint(BaseModel):
@@ -49,6 +51,9 @@ class ParamConstraint(BaseModel):
 
         # 2. Type-specific validation for allowed_values
         if self.allowed_values is not None:
+            if not self.allowed_values:
+                raise ValueError("allowed_values cannot be empty if specified")
+
             if self.type is not None:
                 types_map: dict[str, type | tuple[type, ...]] = {
                     "string": str,
@@ -65,10 +70,6 @@ class ParamConstraint(BaseModel):
             else:
                 # If type is None, ensure all elements in allowed_values are the same type
                 first_type = type(self.allowed_values[0])
-                # For "number" convenience, treat int and float as compatible if the
-                # first is one of them?
-                # But the requirement said "homogeneous", so let's stick to strict
-                # type(val) == first_type unless we want to be fancy.
                 for val in self.allowed_values:
                     if type(val) is not first_type:
                         raise ValueError(
@@ -76,11 +77,24 @@ class ParamConstraint(BaseModel):
                             f"got mixture of {first_type.__name__} and {type(val).__name__}"
                         )
 
-        # 3. ReDoS mitigation: Cap max_length at 4096
-        if self.max_length is not None and self.max_length > 4096:
-            raise ValueError("max_length exceeds ReDoS mitigation limit (4096)")
+        # 3. String-specific validation: pattern and max_length
+        if self.pattern is not None:
+            if self.max_length is None:
+                raise ValueError("pattern requires max_length to be set (ReDoS mitigation)")
+            if len(self.pattern) > MAX_PATTERN_LENGTH:
+                raise ValueError(f"pattern exceeds {MAX_PATTERN_LENGTH} chars (ReDoS mitigation)")
+            try:
+                re.compile(self.pattern)
+            except re.error as exc:
+                raise ValueError(f"invalid regex pattern: {exc}") from exc
 
-        # (System limit check removed or replaced by the tighter 4096 limit)
+        # 4. Limit max_length to MAX_PARAM_LENGTH and enforce ReDoS mitigation cap
+        if self.max_length is not None:
+            if self.max_length > MAX_PARAM_LENGTH:
+                raise ValueError(f"max_length exceeds system limit ({MAX_PARAM_LENGTH})")
+            if self.max_length > RE_DOS_MAX_LENGTH:
+                raise ValueError(f"max_length exceeds ReDoS mitigation limit ({RE_DOS_MAX_LENGTH})")
+
         return self
 
 
@@ -110,7 +124,7 @@ class GatewayPolicy(BaseModel):
     @model_validator(mode="after")
     def _verify_references(self) -> Self:
         # 1. intent.output_filter は output_filters に存在
-        # 5. guardrail keys exist in allowed_tools & param constraints validation
+        # 5. guardrail keys exist in allowed_tools
         for iname, intent in self.intents.items():
             if intent.output_filter not in self.output_filters:
                 raise ValueError(
@@ -118,29 +132,9 @@ class GatewayPolicy(BaseModel):
                 )
 
             allowed_set = set(intent.allowed_tools)
-            for tname, guardrail in intent.guardrails.items():
+            for tname in intent.guardrails:
                 if tname not in allowed_set:
                     raise ValueError(f"intent {iname!r} guardrail {tname!r} not in allowed_tools")
-
-                for pname, constraint in guardrail.params.items():
-                    if constraint.pattern is not None:
-                        if constraint.max_length is None:
-                            raise ValueError(
-                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
-                                "pattern requires max_length to be set (ReDoS mitigation)"
-                            )
-                        if len(constraint.pattern) > 200:
-                            raise ValueError(
-                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
-                                "pattern exceeds 200 chars (ReDoS mitigation)"
-                            )
-                        try:
-                            re.compile(constraint.pattern)
-                        except re.error as exc:
-                            raise ValueError(
-                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
-                                f"invalid regex pattern: {exc}"
-                            ) from exc
 
         # 2. agent.allowed_intents は intents に存在
         for aname, agent in self.agents.items():

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -63,6 +63,11 @@ class ParamConstraint(BaseModel):
                 }
                 expected_type = types_map[self.type]
                 for val in self.allowed_values:
+                    # Booleans are subclasses of int in Python, but for policy enforcement
+                    # we treat them as distinct types.
+                    if self.type in ("integer", "number") and isinstance(val, bool):
+                        raise ValueError(f"allowed_values must be {self.type}, got boolean")
+
                     if not isinstance(val, expected_type):
                         raise ValueError(
                             f"allowed_values must be {self.type}, got {type(val).__name__}"

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -23,13 +23,42 @@ class OutputFilterDef(BaseModel):
     schemas: dict[str, StructuralAllowlistSchema] | None = None
 
 
+MAX_PARAM_LENGTH = 1048576  # 1MB
+
+
 class ParamConstraint(BaseModel):
     model_config = ConfigDict(frozen=True)
     type: Literal["string", "integer", "number", "boolean"] | None = None
     max_length: int | None = None
     pattern: str | None = None
-    allowed_values: list[str] | None = None
+    allowed_values: list[str | int | float | bool] | None = None
     forbidden: bool = False
+
+    @model_validator(mode="after")
+    def validate_consistency(self) -> Self:
+        if self.type != "string":
+            if self.pattern is not None:
+                raise ValueError("pattern is only allowed for type='string'")
+            if self.max_length is not None:
+                raise ValueError("max_length is only allowed for type='string'")
+
+        if self.allowed_values is not None and self.type is not None:
+            expected_type = {
+                "string": str,
+                "integer": int,
+                "number": (int, float),
+                "boolean": bool,
+            }[self.type]
+            for val in self.allowed_values:
+                if not isinstance(val, expected_type):
+                    raise ValueError(
+                        f"allowed_values must be {self.type}, got {type(val).__name__}"
+                    )
+
+        if self.max_length is not None and self.max_length > MAX_PARAM_LENGTH:
+            raise ValueError(f"max_length exceeds system limit ({MAX_PARAM_LENGTH})")
+
+        return self
 
 
 class ToolGuardrail(BaseModel):

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -58,31 +58,37 @@ class GatewayPolicy(BaseModel):
     @model_validator(mode="after")
     def _verify_references(self) -> Self:
         # 1. intent.output_filter は output_filters に存在
+        # 5. guardrail keys exist in allowed_tools & param constraints validation
         for iname, intent in self.intents.items():
             if intent.output_filter not in self.output_filters:
                 raise ValueError(
                     f"intent {iname!r} references unknown output_filter {intent.output_filter!r}"
                 )
 
-            # 5. guardrail keys exist in allowed_tools
-            for tname in intent.guardrails:
-                if tname not in intent.allowed_tools:
+            allowed_set = set(intent.allowed_tools)
+            for tname, guardrail in intent.guardrails.items():
+                if tname not in allowed_set:
                     raise ValueError(f"intent {iname!r} guardrail {tname!r} not in allowed_tools")
 
-            # 6. param constraints validation
-            for tname, guardrail in intent.guardrails.items():
                 for pname, constraint in guardrail.params.items():
                     if constraint.pattern is not None:
                         if constraint.max_length is None:
                             raise ValueError(
-                                f"intent {iname!r} tool {tname!r} param {pname!r} "
-                                "has pattern but missing max_length"
+                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
+                                "pattern requires max_length to be set (ReDoS mitigation)"
                             )
                         if len(constraint.pattern) > 200:
                             raise ValueError(
-                                f"intent {iname!r} tool {tname!r} param {pname!r} "
-                                "pattern is too long (> 200)"
+                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
+                                "pattern exceeds 200 chars (ReDoS mitigation)"
                             )
+                        try:
+                            re.compile(constraint.pattern)
+                        except re.error as exc:
+                            raise ValueError(
+                                f"intent {iname!r} tool {tname!r} param {pname!r}: "
+                                f"invalid regex pattern: {exc}"
+                            ) from exc
 
         # 2. agent.allowed_intents は intents に存在
         for aname, agent in self.agents.items():
@@ -96,7 +102,7 @@ class GatewayPolicy(BaseModel):
                     f"output_filter {fname!r} type=structural_allowlist requires schemas"
                 )
         # 4. structural_allowlist の schema キーは、
-        # そのフィルターを使用している intent.allowed_tools に含まれる
+        # そのフィルターを使用している intent.allowed_tools にに含まれる
         for fname, fdef in self.output_filters.items():
             if fdef.type != "structural_allowlist" or fdef.schemas is None:
                 continue
@@ -113,43 +119,4 @@ class GatewayPolicy(BaseModel):
                         f"output_filter {fname!r} schema key {tool_name!r} is not "
                         "referenced by any intent that uses this filter (typo?)"
                     )
-        # 5. guardrails のキーは allowed_tools に含まれる必要がある
-        #    （ReDoS 対策バリデーションも含む）
-        for iname, intent in self.intents.items():
-            allowed_set = set(intent.allowed_tools)
-            for tool_name, guardrail in intent.guardrails.items():
-                if tool_name not in allowed_set:
-                    raise ValueError(
-                        f"intent {iname!r} guardrail references unknown tool {tool_name!r}"
-                    )
-
-                for param_name, constraint in guardrail.params.items():
-                    if constraint.allowed_values is not None and not all(
-                        isinstance(value, str) for value in constraint.allowed_values
-                    ):
-                        raise ValueError(
-                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
-                            "allowed_values must contain only strings"
-                        )
-
-                    if constraint.pattern is None:
-                        continue
-
-                    if len(constraint.pattern) > 200:
-                        raise ValueError(
-                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
-                            "pattern exceeds 200 chars (ReDoS mitigation)"
-                        )
-                    try:
-                        re.compile(constraint.pattern)
-                    except re.error as exc:
-                        raise ValueError(
-                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
-                            f"invalid regex pattern: {exc}"
-                        ) from exc
-                    if constraint.max_length is None:
-                        raise ValueError(
-                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
-                            "pattern requires max_length to be set (ReDoS mitigation)"
-                        )
         return self

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -6,6 +6,7 @@ to start with a malformed policy (Fail-fast / Default Deny).
 
 from __future__ import annotations
 
+import re
 from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -22,10 +23,24 @@ class OutputFilterDef(BaseModel):
     schemas: dict[str, StructuralAllowlistSchema] | None = None
 
 
+class ParamConstraint(BaseModel):
+    type: Literal["string", "integer", "number", "boolean"] | None = None
+    max_length: int | None = None
+    pattern: str | None = None
+    allowed_values: list[str] | None = None
+    forbidden: bool = False
+
+
+class ToolGuardrail(BaseModel):
+    params: dict[str, ParamConstraint] = Field(default_factory=dict)
+    requires_approval: bool = False
+
+
 class IntentPolicy(BaseModel):
     description: str
     allowed_tools: list[str] = Field(..., min_length=1)
     output_filter: str
+    guardrails: dict[str, ToolGuardrail] = Field(default_factory=dict)
 
 
 class AgentPolicy(BaseModel):
@@ -75,4 +90,43 @@ class GatewayPolicy(BaseModel):
                         f"output_filter {fname!r} schema key {tool_name!r} is not "
                         "referenced by any intent that uses this filter (typo?)"
                     )
+        # 5. guardrails のキーは allowed_tools に含まれる必要がある
+        #    （ReDoS 対策バリデーションも含む）
+        for iname, intent in self.intents.items():
+            allowed_set = set(intent.allowed_tools)
+            for tool_name, guardrail in intent.guardrails.items():
+                if tool_name not in allowed_set:
+                    raise ValueError(
+                        f"intent {iname!r} guardrail references unknown tool {tool_name!r}"
+                    )
+
+                for param_name, constraint in guardrail.params.items():
+                    if constraint.allowed_values is not None and not all(
+                        isinstance(value, str) for value in constraint.allowed_values
+                    ):
+                        raise ValueError(
+                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
+                            "allowed_values must contain only strings"
+                        )
+
+                    if constraint.pattern is None:
+                        continue
+
+                    if len(constraint.pattern) > 200:
+                        raise ValueError(
+                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
+                            "pattern exceeds 200 chars (ReDoS mitigation)"
+                        )
+                    try:
+                        re.compile(constraint.pattern)
+                    except re.error as exc:
+                        raise ValueError(
+                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
+                            f"invalid regex pattern: {exc}"
+                        ) from exc
+                    if constraint.max_length is None:
+                        raise ValueError(
+                            f"intent {iname!r} tool {tool_name!r} param {param_name!r}: "
+                            "pattern requires max_length to be set (ReDoS mitigation)"
+                        )
         return self

--- a/src/mcp_gateway/policy/models.py
+++ b/src/mcp_gateway/policy/models.py
@@ -36,28 +36,51 @@ class ParamConstraint(BaseModel):
 
     @model_validator(mode="after")
     def validate_consistency(self) -> Self:
-        if self.type != "string":
+        # 1. pattern/max_length are only allowed for "string" or when type is None
+        if self.type not in (None, "string"):
             if self.pattern is not None:
-                raise ValueError("pattern is only allowed for type='string'")
+                raise ValueError(
+                    f"pattern is only allowed for type='string', got type={self.type!r}"
+                )
             if self.max_length is not None:
-                raise ValueError("max_length is only allowed for type='string'")
+                raise ValueError(
+                    f"max_length is only allowed for type='string', got type={self.type!r}"
+                )
 
-        if self.allowed_values is not None and self.type is not None:
-            expected_type = {
-                "string": str,
-                "integer": int,
-                "number": (int, float),
-                "boolean": bool,
-            }[self.type]
-            for val in self.allowed_values:
-                if not isinstance(val, expected_type):
-                    raise ValueError(
-                        f"allowed_values must be {self.type}, got {type(val).__name__}"
-                    )
+        # 2. Type-specific validation for allowed_values
+        if self.allowed_values is not None:
+            if self.type is not None:
+                types_map: dict[str, type | tuple[type, ...]] = {
+                    "string": str,
+                    "integer": int,
+                    "number": (int, float),
+                    "boolean": bool,
+                }
+                expected_type = types_map[self.type]
+                for val in self.allowed_values:
+                    if not isinstance(val, expected_type):
+                        raise ValueError(
+                            f"allowed_values must be {self.type}, got {type(val).__name__}"
+                        )
+            else:
+                # If type is None, ensure all elements in allowed_values are the same type
+                first_type = type(self.allowed_values[0])
+                # For "number" convenience, treat int and float as compatible if the
+                # first is one of them?
+                # But the requirement said "homogeneous", so let's stick to strict
+                # type(val) == first_type unless we want to be fancy.
+                for val in self.allowed_values:
+                    if type(val) is not first_type:
+                        raise ValueError(
+                            f"allowed_values must be homogeneous when type is None, "
+                            f"got mixture of {first_type.__name__} and {type(val).__name__}"
+                        )
 
-        if self.max_length is not None and self.max_length > MAX_PARAM_LENGTH:
-            raise ValueError(f"max_length exceeds system limit ({MAX_PARAM_LENGTH})")
+        # 3. ReDoS mitigation: Cap max_length at 4096
+        if self.max_length is not None and self.max_length > 4096:
+            raise ValueError("max_length exceeds ReDoS mitigation limit (4096)")
 
+        # (System limit check removed or replaced by the tighter 4096 limit)
         return self
 
 

--- a/src/mcp_gateway/server.py
+++ b/src/mcp_gateway/server.py
@@ -202,7 +202,11 @@ def build_router(
             filter_ = build_filter(policy.output_filters[record.output_filter_profile])
             proxy = ToolProxy(upstream=upstream, filter_=filter_)
             try:
-                payload = await proxy.call_through(tool_name=tool_name, arguments=arguments)
+                payload = await proxy.call_through(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    guardrail=record.guardrails.get(tool_name),
+                )
             except PolicyError as exc:
                 audit.log(
                     ev="call",

--- a/src/mcp_gateway/tools/proxy.py
+++ b/src/mcp_gateway/tools/proxy.py
@@ -7,6 +7,8 @@ from typing import Any, Protocol
 
 from mcp_gateway.errors import PolicyError
 from mcp_gateway.filters.protocol import OutputFilter
+from mcp_gateway.policy.engine import PolicyEngine
+from mcp_gateway.policy.models import ToolGuardrail
 
 _SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"),
@@ -39,9 +41,18 @@ class ToolProxy:
         self._upstream = upstream
         self._filter = filter_
 
-    async def call_through(self, *, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async def call_through(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        guardrail: ToolGuardrail | None = None,
+    ) -> dict[str, Any]:
         if _contains_secret(arguments):
             raise PolicyError("arguments contain secret-like content")
+
+        PolicyEngine.validate_call(tool_name=tool_name, arguments=arguments, guardrail=guardrail)
+
         payload = await self._upstream.call_tool(tool_name, arguments)
         if _contains_secret(payload):
             raise PolicyError("upstream response contains secret-like content")

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -2257,7 +2257,7 @@ class TestRuntimeValidation:
         from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
 
         guardrail = ToolGuardrail(
-            params={"id": ParamConstraint(type="string", pattern="^ID-[0-9]+$")}
+            params={"id": ParamConstraint(type="string", pattern="^ID-[0-9]+$", max_length=10)}
         )
         # Valid
         PolicyEngine.validate_call(

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -2060,7 +2060,7 @@ class TestIBACModels:
     def test_verify_references_pattern_without_max_length_raises(self):
         from mcp_gateway.policy.models import GatewayPolicy
 
-        with pytest.raises(ValidationError, match="missing max_length"):
+        with pytest.raises(ValidationError, match="pattern requires max_length"):
             GatewayPolicy.model_validate(
                 {
                     "version": 1,
@@ -2082,7 +2082,7 @@ class TestIBACModels:
     def test_verify_references_pattern_too_long_raises(self):
         from mcp_gateway.policy.models import GatewayPolicy
 
-        with pytest.raises(ValidationError, match="pattern is too long"):
+        with pytest.raises(ValidationError, match="pattern exceeds 200 chars"):
             GatewayPolicy.model_validate(
                 {
                     "version": 1,
@@ -2111,7 +2111,7 @@ class TestIBACModels:
     def test_verify_references_pattern_empty_string_requires_max_length(self):
         from mcp_gateway.policy.models import GatewayPolicy
 
-        with pytest.raises(ValidationError, match="missing max_length"):
+        with pytest.raises(ValidationError, match="pattern requires max_length"):
             GatewayPolicy.model_validate(
                 {
                     "version": 1,

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -2268,3 +2268,33 @@ class TestRuntimeValidation:
             PolicyEngine.validate_call(
                 tool_name="test", arguments={"id": "abc"}, guardrail=guardrail
             )
+
+    def test_validate_call_requires_approval(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ToolGuardrail
+
+        guardrail = ToolGuardrail(requires_approval=True)
+        with pytest.raises(PolicyError, match="requires manual approval"):
+            PolicyEngine.validate_call(
+                tool_name="restricted_tool", arguments={}, guardrail=guardrail
+            )
+
+    def test_validate_call_numeric_bool_rejection(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        # Integer constraint
+        guardrail_int = ToolGuardrail(params={"age": ParamConstraint(type="integer")})
+        with pytest.raises(PolicyError, match="must be integer, got boolean"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"age": True}, guardrail=guardrail_int
+            )
+
+        # Number constraint
+        guardrail_num = ToolGuardrail(params={"price": ParamConstraint(type="number")})
+        with pytest.raises(PolicyError, match="must be number, got boolean"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"price": False}, guardrail=guardrail_num
+            )

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -908,7 +908,7 @@ class TestPolicyEngine:
 
         guardrails = {
             "tool_a": ToolGuardrail(
-                params={"p": ParamConstraint(max_length=10)}, requires_approval=True
+                params={"p": ParamConstraint(type="string", max_length=10)}, requires_approval=True
             )
         }
         policy = GatewayPolicy(
@@ -1089,6 +1089,7 @@ class TestSessionLifecycle:
             agent_id="a",
             intent="read_only_recall",
             caps=frozenset({"memory_search"}),
+            guardrails={},
             output_filter_profile="recall_safe",
         )
         assert isinstance(rec, SessionRecord)
@@ -1107,7 +1108,13 @@ class TestSessionLifecycle:
         import mcp_gateway.auth.session as sess
 
         reg = self._make_registry(ttl=10)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="none_f",
+        )
         future = rec.expires_at + timedelta(seconds=1)
         monkeypatch.setattr(sess, "_utcnow", lambda: future)
         from mcp_gateway.errors import SessionError
@@ -1121,7 +1128,13 @@ class TestSessionLifecycle:
         import mcp_gateway.auth.session as sess
 
         reg = self._make_registry(ttl=600, idle=5)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="none_f",
+        )
         original = sess._utcnow()
         monkeypatch.setattr(sess, "_utcnow", lambda: original + timedelta(seconds=10))
         from mcp_gateway.errors import SessionError
@@ -1135,7 +1148,13 @@ class TestSessionLifecycle:
         import mcp_gateway.auth.session as sess
 
         reg = self._make_registry(ttl=600, idle=5)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="none_f",
+        )
         original = sess._utcnow()
         monkeypatch.setattr(sess, "_utcnow", lambda: original + timedelta(seconds=3))
         reg.touch(rec.session_id)
@@ -1147,7 +1166,13 @@ class TestSessionLifecycle:
         from mcp_gateway.errors import SessionError
 
         reg = self._make_registry()
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="none_f",
+        )
         reg.remove(rec.session_id)
         with pytest.raises(SessionError):
             reg.lookup(rec.session_id)
@@ -1156,7 +1181,13 @@ class TestSessionLifecycle:
         from dataclasses import FrozenInstanceError
 
         reg = self._make_registry()
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="none_f")
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="none_f",
+        )
         with pytest.raises(FrozenInstanceError):
             rec.agent_id = "other"  # type: ignore[misc]
 
@@ -2029,7 +2060,7 @@ class TestIBACModels:
             output_filter="f",
             guardrails={
                 "tool_a": ToolGuardrail(
-                    params={"q": ParamConstraint(max_length=512)},
+                    params={"q": ParamConstraint(type="string", max_length=512)},
                     requires_approval=False,
                 )
             },
@@ -2071,7 +2102,9 @@ class TestIBACModels:
                             "allowed_tools": ["tool_a"],
                             "output_filter": "f",
                             "guardrails": {
-                                "tool_a": {"params": {"query": {"pattern": "^[a-z]+$"}}}
+                                "tool_a": {
+                                    "params": {"query": {"type": "string", "pattern": "^[a-z]+$"}}
+                                }
                             },
                         }
                     },
@@ -2096,6 +2129,7 @@ class TestIBACModels:
                                 "tool_a": {
                                     "params": {
                                         "query": {
+                                            "type": "string",
                                             "pattern": "a" * 201,
                                             "max_length": 512,
                                         }
@@ -2121,7 +2155,9 @@ class TestIBACModels:
                             "description": "x",
                             "allowed_tools": ["tool_a"],
                             "output_filter": "f",
-                            "guardrails": {"tool_a": {"params": {"query": {"pattern": ""}}}},
+                            "guardrails": {
+                                "tool_a": {"params": {"query": {"type": "string", "pattern": ""}}}
+                            },
                         }
                     },
                     "agents": {},
@@ -2158,3 +2194,77 @@ class TestIBACModels:
             }
         )
         assert "tool_a" in policy.intents["intent_a"].guardrails
+
+
+class TestRuntimeValidation:
+    def test_validate_call_forbidden(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        guardrail = ToolGuardrail(params={"secret": ParamConstraint(forbidden=True)})
+        with pytest.raises(PolicyError, match="parameter 'secret' is forbidden"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"secret": "val"}, guardrail=guardrail
+            )
+
+    def test_validate_call_type_mismatch(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        guardrail = ToolGuardrail(params={"count": ParamConstraint(type="integer")})
+        with pytest.raises(PolicyError, match="must be integer"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"count": "not_int"}, guardrail=guardrail
+            )
+
+    def test_validate_call_allowed_values(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        guardrail = ToolGuardrail(
+            params={"color": ParamConstraint(type="string", allowed_values=["red", "blue"])}
+        )
+        # Valid
+        PolicyEngine.validate_call(
+            tool_name="test", arguments={"color": "red"}, guardrail=guardrail
+        )
+        # Invalid
+        with pytest.raises(PolicyError, match="has invalid value 'green'"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"color": "green"}, guardrail=guardrail
+            )
+
+    def test_validate_call_max_length(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        guardrail = ToolGuardrail(params={"name": ParamConstraint(type="string", max_length=5)})
+        # Valid
+        PolicyEngine.validate_call(tool_name="test", arguments={"name": "abc"}, guardrail=guardrail)
+        # Invalid
+        with pytest.raises(PolicyError, match="exceeds max_length"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"name": "abcdef"}, guardrail=guardrail
+            )
+
+    def test_validate_call_pattern(self):
+        from mcp_gateway.errors import PolicyError
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import ParamConstraint, ToolGuardrail
+
+        guardrail = ToolGuardrail(
+            params={"id": ParamConstraint(type="string", pattern="^ID-[0-9]+$")}
+        )
+        # Valid
+        PolicyEngine.validate_call(
+            tool_name="test", arguments={"id": "ID-123"}, guardrail=guardrail
+        )
+        # Invalid
+        with pytest.raises(PolicyError, match="does not match required pattern"):
+            PolicyEngine.validate_call(
+                tool_name="test", arguments={"id": "abc"}, guardrail=guardrail
+            )

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1946,3 +1946,160 @@ class TestContextStoreUntouched:
                     if is_bad:
                         bad.append(f"{mod_info.name}: from {node.module or ''} import ...")
         assert bad == [], f"mcp_gateway imports context_store directly: {bad}"
+
+
+class TestIBACModels:
+    """ParamConstraint / ToolGuardrail / IntentPolicy.guardrails の単体テスト。"""
+
+    def test_param_constraint_defaults(self):
+        from mcp_gateway.policy.models import ParamConstraint
+
+        c = ParamConstraint()
+        assert c.type is None
+        assert c.max_length is None
+        assert c.pattern is None
+        assert c.allowed_values is None
+        assert c.forbidden is False
+
+    def test_param_constraint_accepts_all_fields(self):
+        from mcp_gateway.policy.models import ParamConstraint
+
+        c = ParamConstraint(
+            type="string", max_length=100, pattern="^[a-z]+$", allowed_values=["foo"]
+        )
+        assert c.type == "string"
+        assert c.max_length == 100
+        assert c.pattern == "^[a-z]+$"
+        assert c.allowed_values == ["foo"]
+
+    def test_tool_guardrail_defaults(self):
+        from mcp_gateway.policy.models import ToolGuardrail
+
+        g = ToolGuardrail()
+        assert g.params == {}
+        assert g.requires_approval is False
+
+    def test_intent_policy_accepts_guardrails(self):
+        from mcp_gateway.policy.models import IntentPolicy, ParamConstraint, ToolGuardrail
+
+        p = IntentPolicy(
+            description="test",
+            allowed_tools=["tool_a"],
+            output_filter="f",
+            guardrails={
+                "tool_a": ToolGuardrail(
+                    params={"q": ParamConstraint(max_length=512)},
+                    requires_approval=False,
+                )
+            },
+        )
+        assert "tool_a" in p.guardrails
+        assert p.guardrails["tool_a"].params["q"].max_length == 512
+
+    def test_verify_references_guardrail_key_not_in_allowed_tools(self):
+        from pydantic import ValidationError
+
+        from mcp_gateway.policy.models import GatewayPolicy
+
+        with pytest.raises(ValidationError, match="guardrail"):
+            GatewayPolicy.model_validate(
+                {
+                    "version": 1,
+                    "output_filters": {"f": {"type": "none"}},
+                    "intents": {
+                        "intent_a": {
+                            "description": "x",
+                            "allowed_tools": ["tool_a"],
+                            "output_filter": "f",
+                            "guardrails": {"unlisted_tool": {}},
+                        }
+                    },
+                    "agents": {},
+                }
+            )
+
+    def test_verify_references_pattern_without_max_length_raises(self):
+        from pydantic import ValidationError
+
+        from mcp_gateway.policy.models import GatewayPolicy
+
+        with pytest.raises(ValidationError):
+            GatewayPolicy.model_validate(
+                {
+                    "version": 1,
+                    "output_filters": {"f": {"type": "none"}},
+                    "intents": {
+                        "intent_a": {
+                            "description": "x",
+                            "allowed_tools": ["tool_a"],
+                            "output_filter": "f",
+                            "guardrails": {
+                                "tool_a": {"params": {"query": {"pattern": "^[a-z]+$"}}}
+                            },
+                        }
+                    },
+                    "agents": {},
+                }
+            )
+
+    def test_verify_references_pattern_too_long_raises(self):
+        from pydantic import ValidationError
+
+        from mcp_gateway.policy.models import GatewayPolicy
+
+        with pytest.raises(ValidationError):
+            GatewayPolicy.model_validate(
+                {
+                    "version": 1,
+                    "output_filters": {"f": {"type": "none"}},
+                    "intents": {
+                        "intent_a": {
+                            "description": "x",
+                            "allowed_tools": ["tool_a"],
+                            "output_filter": "f",
+                            "guardrails": {
+                                "tool_a": {
+                                    "params": {
+                                        "query": {
+                                            "pattern": "a" * 201,
+                                            "max_length": 512,
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    },
+                    "agents": {},
+                }
+            )
+
+    def test_verify_references_valid_guardrail_passes(self):
+        from mcp_gateway.policy.models import GatewayPolicy
+
+        policy = GatewayPolicy.model_validate(
+            {
+                "version": 1,
+                "output_filters": {"f": {"type": "none"}},
+                "intents": {
+                    "intent_a": {
+                        "description": "x",
+                        "allowed_tools": ["tool_a"],
+                        "output_filter": "f",
+                        "guardrails": {
+                            "tool_a": {
+                                "params": {
+                                    "query": {
+                                        "type": "string",
+                                        "max_length": 512,
+                                        "pattern": "^[^<>]+$",
+                                    }
+                                },
+                                "requires_approval": False,
+                            }
+                        },
+                    }
+                },
+                "agents": {},
+            }
+        )
+        assert "tool_a" in policy.intents["intent_a"].guardrails

--- a/tests/unit/test_param_constraint.py
+++ b/tests/unit/test_param_constraint.py
@@ -1,0 +1,62 @@
+import pytest
+from pydantic import ValidationError
+
+from mcp_gateway.policy.models import ParamConstraint
+
+
+def test_param_constraint_max_length_limit():
+    # 4096 is the new limit
+    ParamConstraint(type="string", max_length=4096)
+
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type="string", max_length=4097)
+    assert "max_length exceeds ReDoS mitigation limit (4096)" in str(excinfo.value)
+
+
+def test_param_constraint_type_none_flexibility():
+    # type=None should allow pattern and max_length
+    pc = ParamConstraint(type=None, pattern=".*", max_length=100)
+    assert pc.type is None
+    assert pc.pattern == ".*"
+    assert pc.max_length == 100
+
+
+def test_param_constraint_homogeneous_allowed_values_when_type_none():
+    # Homogeneous values should pass
+    ParamConstraint(type=None, allowed_values=["a", "b", "c"])
+    ParamConstraint(type=None, allowed_values=[1, 2, 3])
+
+    # Mixture of types should fail
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type=None, allowed_values=["a", 1])
+    assert "allowed_values must be homogeneous when type is None" in str(excinfo.value)
+
+
+def test_param_constraint_type_string_validation():
+    # Valid string constraint
+    ParamConstraint(type="string", pattern="^[a-z]+$", max_length=10)
+
+    # Invalid allowed_values type for string
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type="string", allowed_values=[123])
+    assert "allowed_values must be string, got int" in str(excinfo.value)
+
+
+def test_param_constraint_integer_rejects_string_fields():
+    # integer should NOT allow pattern or max_length
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type="integer", pattern=".*")
+    assert "pattern is only allowed for type='string'" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type="integer", max_length=10)
+    assert "max_length is only allowed for type='string'" in str(excinfo.value)
+
+
+def test_param_constraint_number_compatibility():
+    # number allows both int and float
+    ParamConstraint(type="number", allowed_values=[1, 2.5, 3])
+
+    with pytest.raises(ValidationError) as excinfo:
+        ParamConstraint(type="number", allowed_values=["not a number"])
+    assert "allowed_values must be number, got str" in str(excinfo.value)

--- a/tests/unit/test_session_management.py
+++ b/tests/unit/test_session_management.py
@@ -27,7 +27,9 @@ class TestSessionManagementFixes:
 
     def test_lookup_automatic_touch(self, monkeypatch):
         reg = self._make_registry(ttl=600, idle=10)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="f")
+        rec = reg.create(
+            agent_id="a", intent="i", caps=frozenset(), guardrails={}, output_filter_profile="f"
+        )
 
         start_time = sess._utcnow()
         monkeypatch.setattr(sess, "_utcnow", lambda: start_time + timedelta(seconds=5))
@@ -42,7 +44,9 @@ class TestSessionManagementFixes:
 
     def test_touch_respects_ttl(self, monkeypatch):
         reg = self._make_registry(ttl=10, idle=60)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="f")
+        rec = reg.create(
+            agent_id="a", intent="i", caps=frozenset(), guardrails={}, output_filter_profile="f"
+        )
 
         start_time = sess._utcnow()
         # Advance beyond TTL
@@ -57,7 +61,9 @@ class TestSessionManagementFixes:
 
     def test_touch_does_not_resurrect_idle_session(self, monkeypatch):
         reg = self._make_registry(ttl=600, idle=10)
-        rec = reg.create(agent_id="a", intent="i", caps=frozenset(), output_filter_profile="f")
+        rec = reg.create(
+            agent_id="a", intent="i", caps=frozenset(), guardrails={}, output_filter_profile="f"
+        )
 
         start_time = sess._utcnow()
         # Advance beyond Idle but within TTL
@@ -77,7 +83,11 @@ class TestSessionManagementFixes:
         reg = self._make_registry(ttl=100, idle=50)
 
         s1 = reg.create(
-            agent_id="s1", intent="i", caps=frozenset(), output_filter_profile="f"
+            agent_id="s1",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="f",
         ).session_id
 
         # Move time to t=70
@@ -86,7 +96,11 @@ class TestSessionManagementFixes:
 
         # Create s3 at t=70 (so its last_active is t=70)
         s3 = reg.create(
-            agent_id="s3", intent="i", caps=frozenset(), output_filter_profile="f"
+            agent_id="s3",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="f",
         ).session_id
 
         # Move time to t=130
@@ -100,7 +114,11 @@ class TestSessionManagementFixes:
         # Let's add s2 that remains valid
         # s2: issued at t=130, expires at t=230, last_active at t=130. Valid.
         s2 = reg.create(
-            agent_id="s2", intent="i", caps=frozenset(), output_filter_profile="f"
+            agent_id="s2",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="f",
         ).session_id
 
         reg.purge()
@@ -112,7 +130,11 @@ class TestSessionManagementFixes:
         # Boundary test: exact TTL expiry (t == expires_at)
         # s4 created at t=130, ttl=100 -> expires at t=230
         s4 = reg.create(
-            agent_id="s4", intent="i", caps=frozenset(), output_filter_profile="f"
+            agent_id="s4",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="f",
         ).session_id
         t230 = now_val + timedelta(seconds=230)
         monkeypatch.setattr(sess, "_utcnow", lambda: t230)
@@ -123,7 +145,11 @@ class TestSessionManagementFixes:
         # Boundary test: exact idle expiry (idle_age == idle_timeout)
         # s5 created at t=230, idle=50 -> expires at t=280
         s5 = reg.create(
-            agent_id="s5", intent="i", caps=frozenset(), output_filter_profile="f"
+            agent_id="s5",
+            intent="i",
+            caps=frozenset(),
+            guardrails={},
+            output_filter_profile="f",
         ).session_id
         t280 = now_val + timedelta(seconds=280)
         monkeypatch.setattr(sess, "_utcnow", lambda: t280)
@@ -139,6 +165,7 @@ class TestSessionManagementFixes:
             agent_id="agent1",
             intent="intent1",
             caps=mutable_caps,  # type: ignore
+            guardrails={},
             output_filter_profile="profile1",
         )
 
@@ -148,3 +175,23 @@ class TestSessionManagementFixes:
         # Verify it's a copy/converted so changing mutable_caps doesn't affect it
         mutable_caps.add("cap3")
         assert "cap3" not in rec.caps
+
+    def test_guardrails_copy(self):
+        from mcp_gateway.policy.models import ToolGuardrail
+
+        reg = self._make_registry()
+        guardrails = {"tool1": ToolGuardrail(requires_approval=True)}
+        rec = reg.create(
+            agent_id="a",
+            intent="i",
+            caps=frozenset(["tool1"]),
+            guardrails=guardrails,
+            output_filter_profile="p",
+        )
+
+        # Modify the original dict
+        guardrails["tool2"] = ToolGuardrail(requires_approval=False)
+
+        # The session record should not be affected
+        assert "tool2" not in rec.guardrails
+        assert "tool1" in rec.guardrails


### PR DESCRIPTION
Phase 1 / Task 1.2: models.py に Semantic Guardrails 用のデータモデルを追加する。