### PR TITLE
feat(phase3): PolicyEngine.evaluate_call() with semantic guardrails

### DIFF
--- a/src/mcp_gateway/policy/engine.py
+++ b/src/mcp_gateway/policy/engine.py
@@ -11,10 +11,10 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 
 from mcp_gateway.errors import PolicyError
-from mcp_gateway.policy.models import GatewayPolicy, ToolGuardrail
+from mcp_gateway.policy.models import GatewayPolicy, ParamConstraint, ToolGuardrail
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,6 +23,12 @@ class Grant:
     caps: frozenset[str]
     output_filter_profile: str
     guardrails: MappingProxyType[str, ToolGuardrail]
+
+
+@dataclass(frozen=True, slots=True)
+class CallDecision:
+    status: Literal["ALLOW", "DENY", "REQUIRES_APPROVAL"]
+    reason: str | None = None
 
 
 class PolicyEngine:
@@ -70,6 +76,63 @@ class PolicyEngine:
         if tool_name not in caps:
             raise PolicyError(f"tool {tool_name!r} is not in session capabilities")
 
+    def evaluate_call(
+        self,
+        *,
+        caps: frozenset[str],
+        tool_name: str,
+        arguments: dict[str, Any],
+        intent: str,
+    ) -> CallDecision:
+        if tool_name not in caps:
+            return CallDecision(status="DENY", reason="tool_not_in_caps")
+
+        intent_pol = self._policy.intents.get(intent)
+        if intent_pol is None:
+            return CallDecision(status="DENY", reason="unknown_intent")
+
+        if tool_name not in intent_pol.allowed_tools:
+            return CallDecision(status="DENY", reason="tool_not_allowed_for_intent")
+
+        guardrail = intent_pol.guardrails.get(tool_name)
+        if guardrail is None:
+            return CallDecision(status="ALLOW")
+
+        for param_name, constraint in guardrail.params.items():
+            if constraint.forbidden and param_name in arguments:
+                return CallDecision(status="DENY", reason=f"forbidden_param:{param_name}")
+
+            if param_name not in arguments:
+                continue
+
+            value = arguments[param_name]
+
+            if self._type_mismatch(value, constraint):
+                return CallDecision(status="DENY", reason=f"param_type_mismatch:{param_name}")
+
+            if constraint.max_length is not None and isinstance(value, str):
+                if len(value) > constraint.max_length:
+                    return CallDecision(status="DENY", reason=f"param_too_long:{param_name}")
+
+            if constraint.pattern is not None and isinstance(value, str):
+                if not re.fullmatch(constraint.pattern, value):
+                    return CallDecision(
+                        status="DENY",
+                        reason=f"param_pattern_mismatch:{param_name}",
+                    )
+
+            if constraint.allowed_values is not None:
+                if not self._matches_allowed_value(value, constraint.allowed_values):
+                    return CallDecision(
+                        status="DENY",
+                        reason=f"param_not_in_allowed_values:{param_name}",
+                    )
+
+        if guardrail.requires_approval:
+            return CallDecision(status="REQUIRES_APPROVAL")
+
+        return CallDecision(status="ALLOW")
+
     @staticmethod
     def validate_call(
         *,
@@ -81,7 +144,6 @@ class PolicyEngine:
             return
 
         if guardrail.requires_approval:
-            # Until approval flow is implemented, we must fail closed.
             raise PolicyError(
                 f"tool {tool_name!r} requires manual approval which is not yet implemented"
             )
@@ -93,50 +155,58 @@ class PolicyEngine:
             if param_name not in arguments:
                 continue
 
-            val = arguments[param_name]
+            value = arguments[param_name]
 
-            # 1. Type check
-            if constraint.type is not None:
-                # Booleans are subclasses of int in Python, but for policy enforcement
-                # we treat them as distinct types.
-                if constraint.type in ("integer", "number") and isinstance(val, bool):
-                    raise PolicyError(
-                        f"parameter {param_name!r} must be {constraint.type}, got boolean"
-                    )
+            if PolicyEngine._type_mismatch(value, constraint):
+                expected_type = constraint.type or "string"
+                actual_type = "boolean" if isinstance(value, bool) else type(value).__name__
+                raise PolicyError(
+                    f"parameter {param_name!r} must be {expected_type}, got {actual_type}"
+                )
 
-                types_map: dict[str, type | tuple[type, ...]] = {
-                    "string": str,
-                    "integer": int,
-                    "number": (int, float),
-                    "boolean": bool,
-                }
-                expected_type = types_map[constraint.type]
-                if not isinstance(val, expected_type):
-                    raise PolicyError(
-                        f"parameter {param_name!r} must be {constraint.type}, "
-                        f"got {type(val).__name__}"
-                    )
+            if constraint.allowed_values is not None and not PolicyEngine._matches_allowed_value(
+                value, constraint.allowed_values
+            ):
+                raise PolicyError(
+                    f"parameter {param_name!r} has invalid value {value!r}. "
+                    f"allowed: {constraint.allowed_values}"
+                )
 
-            # 2. Allowed values
-            if constraint.allowed_values is not None:
-                # Use strict type comparison because True == 1 in Python.
-                if not any(v == val and type(v) is type(val) for v in constraint.allowed_values):
-                    raise PolicyError(
-                        f"parameter {param_name!r} has invalid value {val!r}. "
-                        f"allowed: {constraint.allowed_values}"
-                    )
-
-            # 3. String-specific constraints
-            if isinstance(val, str):
-                if constraint.max_length is not None and len(val) > constraint.max_length:
+            if isinstance(value, str):
+                if constraint.max_length is not None and len(value) > constraint.max_length:
                     raise PolicyError(
                         f"parameter {param_name!r} exceeds max_length ({constraint.max_length})"
                     )
-                if constraint.pattern is not None:
-                    # Note: We rely on the fact that pattern was validated at load time.
-                    # For absolute ReDoS safety, one could use a library with timeouts,
-                    # but here we ensure pattern length and max_length are capped.
-                    if not re.fullmatch(constraint.pattern, val):
-                        raise PolicyError(
-                            f"parameter {param_name!r} does not match required pattern"
-                        )
+                if constraint.pattern is not None and not re.fullmatch(constraint.pattern, value):
+                    raise PolicyError(f"parameter {param_name!r} does not match required pattern")
+
+    @staticmethod
+    def _type_mismatch(value: Any, constraint: ParamConstraint) -> bool:
+        constraint_type = constraint.type
+        has_string_constraint = constraint.max_length is not None or constraint.pattern is not None
+
+        if constraint_type is None and not has_string_constraint:
+            return False
+
+        if constraint_type == "string" or (constraint_type is None and has_string_constraint):
+            return not isinstance(value, str)
+
+        if constraint_type == "integer":
+            return isinstance(value, bool) or not isinstance(value, int)
+
+        if constraint_type == "number":
+            return isinstance(value, bool) or not isinstance(value, (int, float))
+
+        if constraint_type == "boolean":
+            return not isinstance(value, bool)
+
+        return False
+
+    @staticmethod
+    def _matches_allowed_value(
+        value: Any,
+        allowed_values: list[str | int | float | bool],
+    ) -> bool:
+        return any(
+            candidate == value and type(candidate) is type(value) for candidate in allowed_values
+        )

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -2422,3 +2422,320 @@ class TestApprovalNotifier:
         assert "secret123" not in log_msg
         assert "mypassword" not in log_msg
         assert "token456" not in log_msg
+
+
+class TestParamConstraint:
+    """evaluate_call() を通じたパラメータ制約の動作テスト。"""
+
+    def _make_engine_and_caps(
+        self,
+        tool_name: str,
+        params: dict,
+        *,
+        requires_approval: bool = False,
+        intent: str = "test_intent",
+    ):
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import (
+            AgentPolicy,
+            GatewayPolicy,
+            IntentPolicy,
+            OutputFilterDef,
+        )
+
+        policy = GatewayPolicy(
+            version=1,
+            output_filters={"f": OutputFilterDef(type="none")},
+            intents={
+                intent: IntentPolicy(
+                    description="test",
+                    allowed_tools=[tool_name],
+                    output_filter="f",
+                    guardrails={
+                        tool_name: {
+                            "params": params,
+                            "requires_approval": requires_approval,
+                        }
+                    },
+                )
+            },
+            agents={"agent-a": AgentPolicy(allowed_intents=[intent])},
+        )
+        return PolicyEngine(policy), frozenset([tool_name])
+
+    def _call(self, engine, caps, tool_name, arguments, intent="test_intent"):
+        return engine.evaluate_call(
+            caps=caps,
+            tool_name=tool_name,
+            arguments=arguments,
+            intent=intent,
+        )
+
+    def test_max_length_boundary_allow(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"query": {"type": "string", "max_length": 512}}
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "a" * 512})
+        assert result.status == "ALLOW"
+
+    def test_max_length_exceeded_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"query": {"type": "string", "max_length": 512}}
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "a" * 513})
+        assert result.status == "DENY"
+        assert result.reason == "param_too_long:query"
+
+    def test_max_length_empty_string_allow(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"query": {"type": "string", "max_length": 512}}
+        )
+        result = self._call(engine, caps, "memory_search", {"query": ""})
+        assert result.status == "ALLOW"
+
+    def test_pattern_full_match_allow(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search",
+            {"query": {"type": "string", "max_length": 100, "pattern": "^[a-z_]+$"}},
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "hello_world"})
+        assert result.status == "ALLOW"
+
+    def test_pattern_partial_match_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search",
+            {"query": {"type": "string", "max_length": 100, "pattern": "^[a-z_]+$"}},
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "hello world!"})
+        assert result.status == "DENY"
+        assert result.reason == "param_pattern_mismatch:query"
+
+    def test_pattern_script_injection_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search",
+            {"query": {"type": "string", "max_length": 100, "pattern": "^[^<>{};]*$"}},
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "<script>alert(1)</script>"})
+        assert result.status == "DENY"
+        assert result.reason == "param_pattern_mismatch:query"
+
+    def test_pattern_unicode_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search",
+            {"query": {"type": "string", "max_length": 100, "pattern": "^[a-z_]+$"}},
+        )
+        result = self._call(engine, caps, "memory_search", {"query": "こんにちは"})
+        assert result.status == "DENY"
+        assert result.reason == "param_pattern_mismatch:query"
+
+    def test_allowed_values_in_list_allow(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"mode": {"type": "string", "allowed_values": ["read", "write"]}}
+        )
+        result = self._call(engine, caps, "memory_search", {"mode": "read"})
+        assert result.status == "ALLOW"
+
+    def test_allowed_values_not_in_list_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"mode": {"type": "string", "allowed_values": ["read", "write"]}}
+        )
+        result = self._call(engine, caps, "memory_search", {"mode": "admin"})
+        assert result.status == "DENY"
+        assert result.reason == "param_not_in_allowed_values:mode"
+
+    def test_forbidden_param_present_deny(self):
+        engine, caps = self._make_engine_and_caps("memory_search", {"secret": {"forbidden": True}})
+        result = self._call(engine, caps, "memory_search", {"secret": "x"})
+        assert result.status == "DENY"
+        assert result.reason == "forbidden_param:secret"
+
+    def test_forbidden_param_absent_allow(self):
+        engine, caps = self._make_engine_and_caps("memory_search", {"secret": {"forbidden": True}})
+        result = self._call(engine, caps, "memory_search", {"query": "hi"})
+        assert result.status == "ALLOW"
+
+    def test_missing_constrained_param_allow(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"query": {"type": "string", "max_length": 512}}
+        )
+        result = self._call(engine, caps, "memory_search", {})
+        assert result.status == "ALLOW"
+
+    def test_type_mismatch_int_for_string_constraint_deny(self):
+        engine, caps = self._make_engine_and_caps(
+            "memory_search", {"query": {"type": "string", "max_length": 512, "pattern": "^[a-z]+$"}}
+        )
+        result = self._call(engine, caps, "memory_search", {"query": 12345})
+        assert result.status == "DENY"
+        assert result.reason == "param_type_mismatch:query"
+
+    def test_type_string_explicit_int_deny(self):
+        engine, caps = self._make_engine_and_caps("memory_search", {"query": {"type": "string"}})
+        result = self._call(engine, caps, "memory_search", {"query": 12345})
+        assert result.status == "DENY"
+        assert result.reason == "param_type_mismatch:query"
+
+    def test_type_integer_bool_excluded_deny(self):
+        engine, caps = self._make_engine_and_caps("memory_search", {"count": {"type": "integer"}})
+        result = self._call(engine, caps, "memory_search", {"count": True})
+        assert result.status == "DENY"
+        assert result.reason == "param_type_mismatch:count"
+
+    def test_type_string_correct_allow(self):
+        engine, caps = self._make_engine_and_caps("memory_search", {"query": {"type": "string"}})
+        result = self._call(engine, caps, "memory_search", {"query": "safe"})
+        assert result.status == "ALLOW"
+
+
+class TestEvaluateCall:
+    """evaluate_call() 分岐全網羅テスト。"""
+
+    def _policy(self):
+        from mcp_gateway.policy.models import (
+            AgentPolicy,
+            GatewayPolicy,
+            IntentPolicy,
+            OutputFilterDef,
+            ParamConstraint,
+            ToolGuardrail,
+        )
+
+        return GatewayPolicy(
+            version=1,
+            output_filters={"f": OutputFilterDef(type="none")},
+            intents={
+                "read_only_recall": IntentPolicy(
+                    description="x",
+                    allowed_tools=["memory_search", "memory_stats"],
+                    output_filter="f",
+                    guardrails={
+                        "memory_search": ToolGuardrail(
+                            params={
+                                "query": ParamConstraint(
+                                    type="string",
+                                    max_length=512,
+                                    pattern="^[^<>]*$",
+                                )
+                            },
+                            requires_approval=False,
+                        )
+                    },
+                ),
+                "curate_memories": IntentPolicy(
+                    description="y",
+                    allowed_tools=["memory_delete"],
+                    output_filter="f",
+                    guardrails={"memory_delete": ToolGuardrail(requires_approval=True)},
+                ),
+            },
+            agents={
+                "agent-a": AgentPolicy(allowed_intents=["read_only_recall", "curate_memories"])
+            },
+        )
+
+    def _engine(self):
+        from mcp_gateway.policy.engine import PolicyEngine
+
+        return PolicyEngine(self._policy())
+
+    def test_tool_not_in_caps_deny(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_search"]),
+            tool_name="memory_delete",
+            arguments={},
+            intent="curate_memories",
+        )
+        assert result.status == "DENY"
+        assert result.reason == "tool_not_in_caps"
+
+    def test_unknown_intent_deny(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_search"]),
+            tool_name="memory_search",
+            arguments={},
+            intent="ghost_intent",
+        )
+        assert result.status == "DENY"
+        assert result.reason == "unknown_intent"
+
+    def test_tool_not_allowed_for_intent_deny(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_search"]),
+            tool_name="memory_search",
+            arguments={},
+            intent="curate_memories",
+        )
+        assert result.status == "DENY"
+        assert result.reason == "tool_not_allowed_for_intent"
+
+    def test_no_guardrail_allow(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_stats"]),
+            tool_name="memory_stats",
+            arguments={},
+            intent="read_only_recall",
+        )
+        assert result.status == "ALLOW"
+
+    def test_all_constraints_pass_allow(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_search"]),
+            tool_name="memory_search",
+            arguments={"query": "safe query"},
+            intent="read_only_recall",
+        )
+        assert result.status == "ALLOW"
+
+    def test_requires_approval_only_params_empty(self):
+        eng = self._engine()
+        result = eng.evaluate_call(
+            caps=frozenset(["memory_delete"]),
+            tool_name="memory_delete",
+            arguments={},
+            intent="curate_memories",
+        )
+        assert result.status == "REQUIRES_APPROVAL"
+
+    def test_param_violation_beats_requires_approval(self):
+        from mcp_gateway.policy.engine import PolicyEngine
+        from mcp_gateway.policy.models import (
+            AgentPolicy,
+            GatewayPolicy,
+            IntentPolicy,
+            OutputFilterDef,
+            ParamConstraint,
+            ToolGuardrail,
+        )
+
+        policy = GatewayPolicy(
+            version=1,
+            output_filters={"f": OutputFilterDef(type="none")},
+            intents={
+                "intent_x": IntentPolicy(
+                    description="x",
+                    allowed_tools=["tool_a"],
+                    output_filter="f",
+                    guardrails={
+                        "tool_a": ToolGuardrail(
+                            params={"query": ParamConstraint(type="string", max_length=512)},
+                            requires_approval=True,
+                        )
+                    },
+                )
+            },
+            agents={"agent-a": AgentPolicy(allowed_intents=["intent_x"])},
+        )
+        eng = PolicyEngine(policy)
+        result = eng.evaluate_call(
+            caps=frozenset(["tool_a"]),
+            tool_name="tool_a",
+            arguments={"query": "a" * 600},
+            intent="intent_x",
+        )
+        assert result.status == "DENY"
+        assert result.reason == "param_too_long:query"


### PR DESCRIPTION
Phase 3: engine.py に CallDecision dataclass と evaluate_call() を追加し、パラメータ制約（max_length / pattern / allowed_values / forbidden / type）を評価できるようにする。