### PR TITLE
feat: wire engine and approval_notifier into app.py DI

### DIFF
--- a/src/mcp_gateway/app.py
+++ b/src/mcp_gateway/app.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncGenerator
 from fastapi import FastAPI
 from pydantic import ValidationError
 
+from mcp_gateway.approval.notifier import LogOnlyApprovalNotifier
 from mcp_gateway.audit.logger import AuditLogger
 from mcp_gateway.auth.api_key import ApiKeyAuthenticator
 from mcp_gateway.auth.handshake import HandshakeService
@@ -120,6 +121,8 @@ def build_app(
             upstream=upstream,
             policy=policy,
             audit=audit,
+            engine=engine,
+            approval_notifier=LogOnlyApprovalNotifier(),
         )
     )
 

--- a/src/mcp_gateway/server.py
+++ b/src/mcp_gateway/server.py
@@ -4,19 +4,22 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from sse_starlette.sse import EventSourceResponse
 
+from mcp_gateway.approval.notifier import ApprovalNotifier, ApprovalRequest
 from mcp_gateway.audit.logger import AuditLogger
 from mcp_gateway.auth.handshake import HandshakeService
 from mcp_gateway.auth.session import SessionRegistry
 from mcp_gateway.errors import AuthError, PolicyError, SessionError, UpstreamError
 from mcp_gateway.filters.factory import build_filter
+from mcp_gateway.policy.engine import Grant, PolicyEngine
 from mcp_gateway.policy.models import GatewayPolicy
-from mcp_gateway.tools.proxy import ToolProxy
+from mcp_gateway.tools.proxy import ToolProxy, _contains_secret
 from mcp_gateway.tools.registry import ToolRegistry
 
 
@@ -44,6 +47,8 @@ def build_router(
     upstream: Any,
     policy: GatewayPolicy,
     audit: AuditLogger,
+    engine: PolicyEngine,
+    approval_notifier: ApprovalNotifier,
 ) -> APIRouter:
     router = APIRouter()
 
@@ -167,22 +172,82 @@ def build_router(
             else:
                 arguments = {}
 
-            if tool_name not in record.caps:
-                audit.log(
-                    ev="call",
-                    decision="deny",
-                    reason="tool_not_in_caps",
-                    agent=record.agent_id,
-                    sid=sid,
-                    tool=tool_name,
-                )
-                return JSONResponse(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": rpc_id,
-                        "error": {"code": -32601, "message": "tool not found"},
-                    }
-                )
+            decision = engine.evaluate_call(
+                grant=Grant(
+                    intent=record.intent,
+                    caps=record.caps,
+                    output_filter_profile=record.output_filter_profile,
+                    guardrails=record.guardrails,
+                ),
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+
+            match decision.status:
+                case "DENY":
+                    audit.log(
+                        ev="call",
+                        decision="deny",
+                        reason=decision.reason,
+                        agent=record.agent_id,
+                        sid=sid,
+                        tool=tool_name,
+                    )
+                    return JSONResponse(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": rpc_id,
+                            "error": {"code": -32601, "message": "tool not found"},
+                        }
+                    )
+                case "REQUIRES_APPROVAL":
+                    if _contains_secret(arguments):
+                        audit.log(
+                            ev="call",
+                            decision="deny",
+                            reason="secret_in_approval_args",
+                            agent=record.agent_id,
+                            sid=sid,
+                            tool=tool_name,
+                        )
+                        return JSONResponse(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": rpc_id,
+                                "error": {"code": -32601, "message": "tool not found"},
+                            }
+                        )
+
+                    audit.log(
+                        ev="call",
+                        decision="requires_approval",
+                        agent=record.agent_id,
+                        sid=sid,
+                        tool=tool_name,
+                    )
+                    await approval_notifier.request_approval(
+                        ApprovalRequest(
+                            session_id=record.session_id,
+                            agent_id=record.agent_id,
+                            intent=record.intent,
+                            tool_name=tool_name,
+                            arguments=arguments,
+                            requested_at=datetime.now(UTC),
+                        )
+                    )
+                    return JSONResponse(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": rpc_id,
+                            "error": {
+                                "code": -32001,
+                                "message": "approval_required",
+                                "data": {"session_id": record.session_id},
+                            },
+                        }
+                    )
+                case "ALLOW":
+                    pass
 
             if record.output_filter_profile not in policy.output_filters:
                 audit.log(

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -1844,6 +1844,122 @@ class TestMcpMessagesEndpoint:
         assert "missing required parameter: name" in body["error"]["message"]
 
 
+class TestServerRequiresApproval:
+    """REQUIRES_APPROVAL パスの /messages エンドポイントテスト。"""
+
+    @pytest.fixture
+    def approval_app(self, tmp_path, monkeypatch):
+        policy = tmp_path / "intents.yaml"
+        policy.write_text(
+            textwrap.dedent(
+                """
+                version: 1
+                output_filters:
+                  f:
+                    type: none
+                intents:
+                  curate_memories:
+                    description: "x"
+                    allowed_tools: [memory_delete]
+                    output_filter: f
+                    guardrails:
+                      memory_delete:
+                        requires_approval: true
+                agents:
+                  agent-a:
+                    allowed_intents: [curate_memories]
+                """
+            ).lstrip()
+        )
+        monkeypatch.setenv("MCP_GATEWAY_POLICY_PATH", str(policy))
+        monkeypatch.setenv("MCP_GATEWAY_API_KEYS_JSON", '{"agent-a":"ck_x"}')
+
+        from unittest.mock import AsyncMock
+
+        from mcp_gateway.app import build_app
+
+        upstream = AsyncMock()
+        upstream.list_tools.return_value = [{"name": "memory_delete"}]
+        return build_app(
+            upstream_override=upstream,
+            initial_tools=upstream.list_tools.return_value,
+        )
+
+    @pytest_asyncio.fixture
+    async def approval_client(self, approval_app):
+        import httpx
+        from httpx import ASGITransport
+
+        transport = ASGITransport(app=approval_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client
+
+    async def _get_session_id(self, client) -> str:
+        async with client.stream(
+            "GET",
+            "/sse",
+            headers={"Authorization": "Bearer ck_x", "X-MCP-Intent": "curate_memories"},
+        ) as resp:
+            assert resp.status_code == 200
+            async for line in resp.aiter_lines():
+                if line.startswith("data:") and "session_id=" in line:
+                    data = line[len("data:") :].strip()
+                    return data.split("session_id=")[1]
+        raise AssertionError("SSE endpoint event did not return session_id")
+
+    @pytest.mark.asyncio
+    async def test_requires_approval_returns_32001(self, approval_client):
+        sid = await self._get_session_id(approval_client)
+        resp = await approval_client.post(
+            f"/messages?session_id={sid}",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "memory_delete", "arguments": {"id": "m-001"}},
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"]["code"] == -32001
+        assert body["error"]["message"] == "approval_required"
+        assert "session_id" in body["error"]["data"]
+
+    @pytest.mark.asyncio
+    async def test_requires_approval_audit_log(self, approval_client, caplog):
+        import logging
+
+        sid = await self._get_session_id(approval_client)
+        with caplog.at_level(logging.INFO):
+            await approval_client.post(
+                f"/messages?session_id={sid}",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "memory_delete", "arguments": {}},
+                },
+            )
+        assert any("approval_required" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_caps_denied_returns_32601(self, approval_client):
+        sid = await self._get_session_id(approval_client)
+        resp = await approval_client.post(
+            f"/messages?session_id={sid}",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "admin_tool", "arguments": {}},
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"]["code"] == -32601
+        assert body["error"]["message"] == "tool not found"
+
+
 class TestEntrypoint:
     def test_main_callable(self, monkeypatch):
         from unittest.mock import patch


### PR DESCRIPTION
Phase 4 / Task 4.4: app.py に LogOnlyApprovalNotifier をインスタンス化し build_router() へ渡す。