### PR TITLE
feat(mcp-gateway): approval decision models (Phase 1 / Task 1)

### DIFF
--- a/src/mcp_gateway/approval/__init__.py
+++ b/src/mcp_gateway/approval/__init__.py
@@ -1,3 +1,11 @@
+from .models import ApprovalDecision, DecisionStatus, ResolveOutcome
 from .notifier import ApprovalNotifier, ApprovalRequest, LogOnlyApprovalNotifier
 
-__all__ = ["ApprovalNotifier", "ApprovalRequest", "LogOnlyApprovalNotifier"]
+__all__ = [
+    "ApprovalDecision",
+    "ApprovalNotifier",
+    "ApprovalRequest",
+    "DecisionStatus",
+    "LogOnlyApprovalNotifier",
+    "ResolveOutcome",
+]

--- a/src/mcp_gateway/approval/models.py
+++ b/src/mcp_gateway/approval/models.py
@@ -1,0 +1,31 @@
+"""Approval decision models shared between registry, server, and notifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DecisionStatus(str, Enum):
+    """Final state of a single approval entry."""
+
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    TIMEOUT = "timeout"
+
+
+class ResolveOutcome(str, Enum):
+    """Result of attempting to resolve an approval through the registry."""
+
+    OK = "ok"
+    NOT_FOUND = "not_found"
+    ALREADY_RESOLVED = "already_resolved"
+    FORBIDDEN = "forbidden"
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDecision:
+    """Resolved decision returned to the suspended caller."""
+
+    status: DecisionStatus
+    reason: str | None = None

--- a/tests/unit/test_approval_models.py
+++ b/tests/unit/test_approval_models.py
@@ -1,0 +1,45 @@
+"""Unit tests for approval decision models."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_gateway.approval.models import (
+    ApprovalDecision,
+    DecisionStatus,
+    ResolveOutcome,
+)
+
+
+class TestDecisionStatus:
+    def test_enum_values(self) -> None:
+        assert DecisionStatus.APPROVED.value == "approved"
+        assert DecisionStatus.REJECTED.value == "rejected"
+        assert DecisionStatus.TIMEOUT.value == "timeout"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(DecisionStatus.APPROVED, str)
+
+
+class TestResolveOutcome:
+    def test_enum_values(self) -> None:
+        assert ResolveOutcome.OK.value == "ok"
+        assert ResolveOutcome.NOT_FOUND.value == "not_found"
+        assert ResolveOutcome.ALREADY_RESOLVED.value == "already_resolved"
+        assert ResolveOutcome.FORBIDDEN.value == "forbidden"
+
+
+class TestApprovalDecision:
+    def test_default_reason_is_none(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.APPROVED)
+        assert d.status is DecisionStatus.APPROVED
+        assert d.reason is None
+
+    def test_with_reason(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.REJECTED, reason="not authorized")
+        assert d.reason == "not authorized"
+
+    def test_is_frozen(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.APPROVED)
+        with pytest.raises((AttributeError, Exception)):
+            d.status = DecisionStatus.REJECTED  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Add `DecisionStatus` and `ResolveOutcome` string enums.
- Add frozen `ApprovalDecision` dataclass.
- Re-export the new symbols from `mcp_gateway.approval`.

## Test plan
- [x] `uv run pytest tests/unit/test_approval_models.py -v` (devcontainer-equivalent)
- [x] `uv run mypy src/ tests/ scripts/`
- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run ruff format --check src/ tests/ scripts/`

Targets Phase 1 base branch; do not merge to master directly.
