### PR TITLE
feat(mcp-gateway): sanitize_reason helper (Phase 1 / Task 2)

### DIFF
--- a/src/mcp_gateway/approval/__init__.py
+++ b/src/mcp_gateway/approval/__init__.py
@@ -1,3 +1,9 @@
 from .notifier import ApprovalNotifier, ApprovalRequest, LogOnlyApprovalNotifier
+from .sanitize import sanitize_reason
 
-__all__ = ["ApprovalNotifier", "ApprovalRequest", "LogOnlyApprovalNotifier"]
+__all__ = [
+    "ApprovalNotifier",
+    "ApprovalRequest",
+    "LogOnlyApprovalNotifier",
+    "sanitize_reason",
+]

--- a/src/mcp_gateway/approval/sanitize.py
+++ b/src/mcp_gateway/approval/sanitize.py
@@ -1,0 +1,27 @@
+"""Reason field sanitizer (control-char strip, whitespace normalize, 256-byte truncate)."""
+
+from __future__ import annotations
+
+import re
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+_WHITESPACE_RE = re.compile(r"\s+")
+_MAX_BYTES = 256
+
+
+def sanitize_reason(reason: str | None) -> str | None:
+    """Normalize and truncate a free-text approval reason for safe logging."""
+    if reason is None:
+        return None
+
+    cleaned = _CONTROL_CHARS_RE.sub("", reason)
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
+    if not cleaned:
+        return None
+
+    encoded = cleaned.encode("utf-8")
+    if len(encoded) <= _MAX_BYTES:
+        return cleaned
+
+    truncated = encoded[:_MAX_BYTES]
+    return truncated.decode("utf-8", errors="ignore")

--- a/tests/unit/test_approval_sanitize.py
+++ b/tests/unit/test_approval_sanitize.py
@@ -1,0 +1,38 @@
+"""Unit tests for sanitize_reason."""
+
+from __future__ import annotations
+
+from mcp_gateway.approval.sanitize import sanitize_reason
+
+
+class TestSanitizeReason:
+    def test_returns_none_for_none(self) -> None:
+        assert sanitize_reason(None) is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert sanitize_reason("") is None
+
+    def test_returns_none_for_whitespace_only(self) -> None:
+        assert sanitize_reason("   \t  ") is None
+
+    def test_strips_ascii_control_chars_except_newline(self) -> None:
+        assert sanitize_reason("a\x00b\x07c") == "abc"
+
+    def test_collapses_consecutive_whitespace(self) -> None:
+        assert sanitize_reason("hello    world\t\tfoo") == "hello world foo"
+
+    def test_trims_outer_whitespace(self) -> None:
+        assert sanitize_reason("  reason text  ") == "reason text"
+
+    def test_truncates_to_256_bytes_utf8(self) -> None:
+        long = "あ" * 100
+        out = sanitize_reason(long)
+        assert out is not None
+        assert len(out.encode("utf-8")) <= 256
+        assert "あ" in out
+
+    def test_preserves_short_ascii(self) -> None:
+        assert sanitize_reason("ok") == "ok"
+
+    def test_preserves_unicode_letters(self) -> None:
+        assert sanitize_reason("理由: テスト") == "理由: テスト"


### PR DESCRIPTION
## Summary
- Add `sanitize_reason()` for approval/audit reason text.
- Re-export the helper from `mcp_gateway.approval`.
- Preserve the Phase 1 base branch state without depending on Task 1.1 symbols.

## Test plan
- [x] `uv run pytest tests/unit/test_approval_sanitize.py -v` (devcontainer-equivalent)
- [x] `uv run mypy src/ tests/ scripts/`
- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run ruff format --check src/ tests/ scripts/`

Targets Phase 1 base.
