### PR TITLE
feat(mcp-gateway): InMemorySessionRegistry eviction hook (Phase 2 / Task 1)

### DIFF
--- a/src/mcp_gateway/auth/session.py
+++ b/src/mcp_gateway/auth/session.py
@@ -7,18 +7,22 @@ return a uniform 404 + close the SSE stream.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import threading
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Iterable, Protocol
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, Iterable, Protocol, cast
 
 from mcp_gateway.errors import SessionError
 
 if TYPE_CHECKING:
     from mcp_gateway.policy.models import ToolGuardrail
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow() -> datetime:
@@ -60,7 +64,13 @@ class SessionRegistry(Protocol):
 class InMemorySessionRegistry:
     """Process-local registry. Replaceable later with a Redis-backed implementation."""
 
-    def __init__(self, ttl_seconds: int, idle_timeout_seconds: int) -> None:
+    def __init__(
+        self,
+        ttl_seconds: int,
+        idle_timeout_seconds: int,
+        *,
+        on_session_evicted: Callable[[str], Awaitable[None]] | None = None,
+    ) -> None:
         if ttl_seconds <= 0:
             raise ValueError(f"ttl_seconds must be positive, got {ttl_seconds}")
         if idle_timeout_seconds <= 0:
@@ -71,6 +81,27 @@ class InMemorySessionRegistry:
         self._records: dict[str, SessionRecord] = {}
         self._last_active: dict[str, datetime] = {}
         self._lock = threading.Lock()
+        self._on_evicted = on_session_evicted
+
+    def _fire_evicted(self, session_id: str) -> None:
+        if self._on_evicted is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        coro = cast(Coroutine[Any, Any, None], self._on_evicted(session_id))
+        task: asyncio.Task[None] = loop.create_task(coro, name=f"session_evict_{session_id[:8]}")
+        task.add_done_callback(self._log_evict_exception)
+
+    @staticmethod
+    def _log_evict_exception(task: asyncio.Task[None]) -> None:
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            logger.error("session_eviction_callback_failed: %s", exc, exc_info=exc)
 
     def create(
         self,
@@ -99,67 +130,80 @@ class InMemorySessionRegistry:
         return rec
 
     def lookup(self, session_id: str) -> SessionRecord:
-        with self._lock:
-            now = _utcnow()
-            rec = self._records.get(session_id)
-            if rec is None:
-                raise SessionError(f"unknown session_id {session_id!r}")
+        evicted: str | None = None
+        try:
+            with self._lock:
+                now = _utcnow()
+                rec = self._records.get(session_id)
+                if rec is None:
+                    raise SessionError(f"unknown session_id {session_id!r}")
 
-            if now >= rec.expires_at:
-                self._records.pop(session_id, None)
-                self._last_active.pop(session_id, None)
-                raise SessionError("session expired (ttl)")
+                if now >= rec.expires_at:
+                    self._records.pop(session_id, None)
+                    self._last_active.pop(session_id, None)
+                    evicted = session_id
+                    raise SessionError("session expired (ttl)")
 
-            last = self._last_active.get(session_id, rec.issued_at)
-            if now - last >= self._idle:
-                self._records.pop(session_id, None)
-                self._last_active.pop(session_id, None)
-                raise SessionError("session expired (idle)")
+                last = self._last_active.get(session_id, rec.issued_at)
+                if now - last >= self._idle:
+                    self._records.pop(session_id, None)
+                    self._last_active.pop(session_id, None)
+                    evicted = session_id
+                    raise SessionError("session expired (idle)")
 
-            # Update idle timer on successful lookup
-            self._last_active[session_id] = now
-            return rec
+                self._last_active[session_id] = now
+                return rec
+        finally:
+            if evicted is not None:
+                self._fire_evicted(evicted)
 
     def touch(self, session_id: str) -> None:
+        evicted: str | None = None
         with self._lock:
             now = _utcnow()
             rec = self._records.get(session_id)
             if rec is None:
                 return
 
-            # Check TTL
             if now >= rec.expires_at:
                 self._records.pop(session_id, None)
                 self._last_active.pop(session_id, None)
-                return
-
-            # Check Idle
-            last = self._last_active.get(session_id, rec.issued_at)
-            if now - last >= self._idle:
-                self._records.pop(session_id, None)
-                self._last_active.pop(session_id, None)
-                return
-
-            self._last_active[session_id] = now
+                evicted = session_id
+            else:
+                last = self._last_active.get(session_id, rec.issued_at)
+                if now - last >= self._idle:
+                    self._records.pop(session_id, None)
+                    self._last_active.pop(session_id, None)
+                    evicted = session_id
+                else:
+                    self._last_active[session_id] = now
+        if evicted is not None:
+            self._fire_evicted(evicted)
 
     def purge(self) -> None:
         """Remove all expired or idle sessions from the registry."""
+        evicted_ids: list[str] = []
         with self._lock:
             now = _utcnow()
-            expired_ids = []
             for sid, rec in self._records.items():
                 if now >= rec.expires_at:
-                    expired_ids.append(sid)
+                    evicted_ids.append(sid)
                     continue
                 last = self._last_active.get(sid, rec.issued_at)
                 if now - last >= self._idle:
-                    expired_ids.append(sid)
+                    evicted_ids.append(sid)
 
-            for sid in expired_ids:
+            for sid in evicted_ids:
                 self._records.pop(sid, None)
                 self._last_active.pop(sid, None)
+        for sid in evicted_ids:
+            self._fire_evicted(sid)
 
     def remove(self, session_id: str) -> None:
+        existed = False
         with self._lock:
+            existed = session_id in self._records
             self._records.pop(session_id, None)
             self._last_active.pop(session_id, None)
+        if existed:
+            self._fire_evicted(session_id)

--- a/tests/unit/test_session_eviction_hook.py
+++ b/tests/unit/test_session_eviction_hook.py
@@ -1,0 +1,155 @@
+"""Unit tests for InMemorySessionRegistry on_session_evicted hook."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import replace
+from datetime import timedelta
+from types import MappingProxyType
+
+import pytest
+
+from mcp_gateway.auth.session import InMemorySessionRegistry
+from mcp_gateway.errors import SessionError
+
+
+def _make_session(reg: InMemorySessionRegistry) -> str:
+    rec = reg.create(
+        agent_id="agent-a",
+        intent="curate_memories",
+        caps=["memory.read"],
+        guardrails=MappingProxyType({}),
+        output_filter_profile="default",
+    )
+    return rec.session_id
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_invoked_on_idle_expiry() -> None:
+    fired: list[str] = []
+
+    async def hook(sid: str) -> None:
+        fired.append(sid)
+
+    reg = InMemorySessionRegistry(ttl_seconds=3600, idle_timeout_seconds=1, on_session_evicted=hook)
+    sid = _make_session(reg)
+    reg._last_active[sid] -= timedelta(seconds=10)  # type: ignore[attr-defined]
+
+    with pytest.raises(SessionError):
+        reg.lookup(sid)
+
+    await asyncio.sleep(0)
+    assert fired == [sid]
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_invoked_on_ttl_expiry() -> None:
+    fired: list[str] = []
+
+    async def hook(sid: str) -> None:
+        fired.append(sid)
+
+    reg = InMemorySessionRegistry(ttl_seconds=1, idle_timeout_seconds=3600, on_session_evicted=hook)
+    sid = _make_session(reg)
+    reg._records[sid] = replace(
+        reg._records[sid], expires_at=reg._records[sid].issued_at - timedelta(seconds=1)
+    )  # type: ignore[attr-defined]
+
+    with pytest.raises(SessionError):
+        reg.lookup(sid)
+
+    await asyncio.sleep(0)
+    assert fired == [sid]
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_invoked_on_remove() -> None:
+    fired: list[str] = []
+
+    async def hook(sid: str) -> None:
+        fired.append(sid)
+
+    reg = InMemorySessionRegistry(
+        ttl_seconds=3600, idle_timeout_seconds=3600, on_session_evicted=hook
+    )
+    sid = _make_session(reg)
+    reg.remove(sid)
+    await asyncio.sleep(0)
+    assert fired == [sid]
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_invoked_on_purge() -> None:
+    fired: list[str] = []
+
+    async def hook(sid: str) -> None:
+        fired.append(sid)
+
+    reg = InMemorySessionRegistry(ttl_seconds=1, idle_timeout_seconds=3600, on_session_evicted=hook)
+    sid_a = _make_session(reg)
+    sid_b = _make_session(reg)
+    for sid in (sid_a, sid_b):
+        reg._records[sid] = replace(
+            reg._records[sid], expires_at=reg._records[sid].issued_at - timedelta(seconds=1)
+        )  # type: ignore[attr-defined]
+
+    reg.purge()
+    await asyncio.sleep(0)
+    assert sorted(fired) == sorted([sid_a, sid_b])
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_logs_exception_when_callback_raises() -> None:
+    from mcp_gateway.auth import session as session_module
+
+    records: list[logging.LogRecord] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    async def boom(sid: str) -> None:
+        raise RuntimeError("explode")
+
+    handler = _CaptureHandler(level=logging.ERROR)
+    session_module.logger.addHandler(handler)
+    session_module.logger.setLevel(logging.ERROR)
+    try:
+        reg = InMemorySessionRegistry(
+            ttl_seconds=3600, idle_timeout_seconds=3600, on_session_evicted=boom
+        )
+        sid = _make_session(reg)
+        reg.remove(sid)
+        for _ in range(10):
+            if records:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        session_module.logger.removeHandler(handler)
+
+    assert any(
+        record.getMessage().startswith("session_eviction_callback_failed") for record in records
+    )
+
+
+@pytest.mark.asyncio
+async def test_eviction_callback_does_not_block_caller() -> None:
+    started = asyncio.Event()
+
+    async def slow(sid: str) -> None:
+        started.set()
+        await asyncio.sleep(0.5)
+
+    reg = InMemorySessionRegistry(
+        ttl_seconds=3600, idle_timeout_seconds=3600, on_session_evicted=slow
+    )
+    sid = _make_session(reg)
+
+    import time
+
+    t0 = time.monotonic()
+    reg.remove(sid)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 0.05
+    await asyncio.wait_for(started.wait(), timeout=0.5)


### PR DESCRIPTION
## Summary
- Add `on_session_evicted` callback support to `InMemorySessionRegistry`.
- Fire the callback for TTL, idle, remove, and purge eviction paths without blocking callers.
- Log callback exceptions through `logger.error`.

## Test plan
- [x] `uv run pytest tests/unit/test_session_eviction_hook.py tests/unit/test_mcp_gateway.py -v` (devcontainer-equivalent)
- [x] `uv run mypy src/ tests/ scripts/`
- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run ruff format --check src/ tests/ scripts/`

Targets Phase 2 base.
