### PR TITLE
feat(mcp-gateway): PendingApprovalRegistry (Phase 1 / Task 3 replay)

### DIFF
--- a/src/mcp_gateway/approval/__init__.py
+++ b/src/mcp_gateway/approval/__init__.py
@@ -1,3 +1,11 @@
+from .models import ApprovalDecision, DecisionStatus, ResolveOutcome
 from .notifier import ApprovalNotifier, ApprovalRequest, LogOnlyApprovalNotifier
 
-__all__ = ["ApprovalNotifier", "ApprovalRequest", "LogOnlyApprovalNotifier"]
+__all__ = [
+    "ApprovalDecision",
+    "ApprovalNotifier",
+    "ApprovalRequest",
+    "DecisionStatus",
+    "LogOnlyApprovalNotifier",
+    "ResolveOutcome",
+]

--- a/src/mcp_gateway/approval/__init__.py
+++ b/src/mcp_gateway/approval/__init__.py
@@ -1,5 +1,6 @@
 from .models import ApprovalDecision, DecisionStatus, ResolveOutcome
 from .notifier import ApprovalNotifier, ApprovalRequest, LogOnlyApprovalNotifier
+from .registry import PendingApprovalRegistry
 
 __all__ = [
     "ApprovalDecision",
@@ -7,5 +8,6 @@ __all__ = [
     "ApprovalRequest",
     "DecisionStatus",
     "LogOnlyApprovalNotifier",
+    "PendingApprovalRegistry",
     "ResolveOutcome",
 ]

--- a/src/mcp_gateway/approval/models.py
+++ b/src/mcp_gateway/approval/models.py
@@ -1,0 +1,31 @@
+"""Approval decision models shared between registry, server, and notifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DecisionStatus(str, Enum):
+    """Final state of a single approval entry."""
+
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    TIMEOUT = "timeout"
+
+
+class ResolveOutcome(str, Enum):
+    """Result of attempting to resolve an approval through the registry."""
+
+    OK = "ok"
+    NOT_FOUND = "not_found"
+    ALREADY_RESOLVED = "already_resolved"
+    FORBIDDEN = "forbidden"
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDecision:
+    """Resolved decision returned to the suspended caller."""
+
+    status: DecisionStatus
+    reason: str | None = None

--- a/src/mcp_gateway/approval/registry.py
+++ b/src/mcp_gateway/approval/registry.py
@@ -1,0 +1,100 @@
+"""In-memory registry of pending approvals (asyncio.Event based)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+
+from mcp_gateway.approval.models import ApprovalDecision, DecisionStatus, ResolveOutcome
+from mcp_gateway.approval.notifier import ApprovalRequest
+from mcp_gateway.errors import PolicyError
+
+
+@dataclass(slots=True)
+class _Pending:
+    event: asyncio.Event
+    session_id: str
+    requester_agent_id: str
+    request: ApprovalRequest
+    decision: ApprovalDecision | None = None
+
+
+class PendingApprovalRegistry:
+    """asyncio.Event-backed map of approval_id -> pending entry."""
+
+    def __init__(self, *, max_pending: int = 1000) -> None:
+        if max_pending <= 0:
+            raise ValueError(f"max_pending must be positive, got {max_pending}")
+        self._lock = asyncio.Lock()
+        self._pending: dict[str, _Pending] = {}
+        self._max_pending = max_pending
+
+    async def register(
+        self,
+        *,
+        session_id: str,
+        requester_agent_id: str,
+        request: ApprovalRequest,
+    ) -> str:
+        async with self._lock:
+            if len(self._pending) >= self._max_pending:
+                raise PolicyError("approval_registry_full")
+            approval_id = uuid.uuid4().hex
+            self._pending[approval_id] = _Pending(
+                event=asyncio.Event(),
+                session_id=session_id,
+                requester_agent_id=requester_agent_id,
+                request=request,
+            )
+            return approval_id
+
+    async def wait_for_decision(self, approval_id: str, *, timeout: float) -> ApprovalDecision:
+        async with self._lock:
+            entry = self._pending.get(approval_id)
+            if entry is None:
+                raise KeyError(approval_id)
+            event = entry.event
+
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            async with self._lock:
+                self._pending.pop(approval_id, None)
+            return ApprovalDecision(status=DecisionStatus.TIMEOUT)
+
+        async with self._lock:
+            entry = self._pending.pop(approval_id, None)
+        if entry is None or entry.decision is None:
+            return ApprovalDecision(status=DecisionStatus.TIMEOUT)
+        return entry.decision
+
+    async def resolve(
+        self,
+        approval_id: str,
+        *,
+        resolver_agent_id: str,
+        status: DecisionStatus,
+        reason: str | None = None,
+    ) -> ResolveOutcome:
+        async with self._lock:
+            entry = self._pending.get(approval_id)
+            if entry is None:
+                return ResolveOutcome.NOT_FOUND
+            if entry.decision is not None:
+                return ResolveOutcome.ALREADY_RESOLVED
+            if resolver_agent_id == entry.requester_agent_id:
+                return ResolveOutcome.FORBIDDEN
+            entry.decision = ApprovalDecision(status=status, reason=reason)
+            entry.event.set()
+            return ResolveOutcome.OK
+
+    async def cancel_session(self, session_id: str) -> None:
+        async with self._lock:
+            for entry in self._pending.values():
+                if entry.session_id == session_id and entry.decision is None:
+                    entry.decision = ApprovalDecision(
+                        status=DecisionStatus.REJECTED,
+                        reason="session_evicted",
+                    )
+                    entry.event.set()

--- a/tests/unit/test_approval_models.py
+++ b/tests/unit/test_approval_models.py
@@ -1,0 +1,45 @@
+"""Unit tests for approval decision models."""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_gateway.approval.models import (
+    ApprovalDecision,
+    DecisionStatus,
+    ResolveOutcome,
+)
+
+
+class TestDecisionStatus:
+    def test_enum_values(self) -> None:
+        assert DecisionStatus.APPROVED.value == "approved"
+        assert DecisionStatus.REJECTED.value == "rejected"
+        assert DecisionStatus.TIMEOUT.value == "timeout"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(DecisionStatus.APPROVED, str)
+
+
+class TestResolveOutcome:
+    def test_enum_values(self) -> None:
+        assert ResolveOutcome.OK.value == "ok"
+        assert ResolveOutcome.NOT_FOUND.value == "not_found"
+        assert ResolveOutcome.ALREADY_RESOLVED.value == "already_resolved"
+        assert ResolveOutcome.FORBIDDEN.value == "forbidden"
+
+
+class TestApprovalDecision:
+    def test_default_reason_is_none(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.APPROVED)
+        assert d.status is DecisionStatus.APPROVED
+        assert d.reason is None
+
+    def test_with_reason(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.REJECTED, reason="not authorized")
+        assert d.reason == "not authorized"
+
+    def test_is_frozen(self) -> None:
+        d = ApprovalDecision(status=DecisionStatus.APPROVED)
+        with pytest.raises((AttributeError, Exception)):
+            d.status = DecisionStatus.REJECTED  # type: ignore[misc]

--- a/tests/unit/test_approval_registry.py
+++ b/tests/unit/test_approval_registry.py
@@ -1,0 +1,153 @@
+"""Unit tests for PendingApprovalRegistry."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from mcp_gateway.approval.models import DecisionStatus, ResolveOutcome
+from mcp_gateway.approval.notifier import ApprovalRequest
+from mcp_gateway.approval.registry import PendingApprovalRegistry
+from mcp_gateway.errors import PolicyError
+
+
+def _req(sid: str = "s1", agent: str = "agent-a") -> ApprovalRequest:
+    return ApprovalRequest(
+        session_id=sid,
+        agent_id=agent,
+        intent="curate_memories",
+        tool_name="memory_delete",
+        arguments={},
+        requested_at=datetime.now(UTC),
+    )
+
+
+class TestRegister:
+    @pytest.mark.asyncio
+    async def test_register_returns_unique_approval_id(self) -> None:
+        reg = PendingApprovalRegistry()
+        a = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        b = await reg.register(session_id="s2", requester_agent_id="agent-a", request=_req("s2"))
+        assert a != b
+        assert len(a) == 32
+
+    @pytest.mark.asyncio
+    async def test_register_raises_policy_error_on_overflow(self) -> None:
+        reg = PendingApprovalRegistry(max_pending=1)
+        await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        with pytest.raises(PolicyError, match="approval_registry_full"):
+            await reg.register(session_id="s2", requester_agent_id="agent-a", request=_req("s2"))
+
+
+class TestWaitForDecision:
+    @pytest.mark.asyncio
+    async def test_returns_approved_when_resolved(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        outcome = await reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.APPROVED)
+        assert outcome is ResolveOutcome.OK
+        d = await reg.wait_for_decision(aid, timeout=0.1)
+        assert d.status is DecisionStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_returns_rejected_when_resolved(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        await reg.resolve(
+            aid,
+            resolver_agent_id="op",
+            status=DecisionStatus.REJECTED,
+            reason="policy violation",
+        )
+        d = await reg.wait_for_decision(aid, timeout=0.1)
+        assert d.status is DecisionStatus.REJECTED
+        assert d.reason == "policy violation"
+
+    @pytest.mark.asyncio
+    async def test_times_out(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        d = await reg.wait_for_decision(aid, timeout=0.05)
+        assert d.status is DecisionStatus.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_raises_keyerror(self) -> None:
+        reg = PendingApprovalRegistry()
+        with pytest.raises(KeyError):
+            await reg.wait_for_decision("does-not-exist", timeout=0.05)
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_unknown_id_returns_not_found(self) -> None:
+        reg = PendingApprovalRegistry()
+        outcome = await reg.resolve("nope", resolver_agent_id="op", status=DecisionStatus.APPROVED)
+        assert outcome is ResolveOutcome.NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_returns_already_resolved(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        first = await reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.APPROVED)
+        second = await reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.REJECTED)
+        assert first is ResolveOutcome.OK
+        assert second is ResolveOutcome.ALREADY_RESOLVED
+
+    @pytest.mark.asyncio
+    async def test_self_approval_returns_forbidden(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(
+            session_id="s1", requester_agent_id="agent-a", request=_req(agent="agent-a")
+        )
+        outcome = await reg.resolve(
+            aid, resolver_agent_id="agent-a", status=DecisionStatus.APPROVED
+        )
+        assert outcome is ResolveOutcome.FORBIDDEN
+        d = await reg.wait_for_decision(aid, timeout=0.05)
+        assert d.status is DecisionStatus.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_concurrent_resolve_is_safe(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid = await reg.register(session_id="s1", requester_agent_id="agent-a", request=_req())
+        results = await asyncio.gather(
+            reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.APPROVED),
+            reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.APPROVED),
+            reg.resolve(aid, resolver_agent_id="op", status=DecisionStatus.APPROVED),
+        )
+        ok_count = sum(1 for r in results if r is ResolveOutcome.OK)
+        already_count = sum(1 for r in results if r is ResolveOutcome.ALREADY_RESOLVED)
+        assert ok_count == 1
+        assert already_count == 2
+
+
+class TestCancelSession:
+    @pytest.mark.asyncio
+    async def test_rejects_pending(self) -> None:
+        reg = PendingApprovalRegistry()
+        aid_s1_a = await reg.register(
+            session_id="s1", requester_agent_id="agent-a", request=_req("s1")
+        )
+        aid_s1_b = await reg.register(
+            session_id="s1", requester_agent_id="agent-b", request=_req("s1", "agent-b")
+        )
+        aid_s2 = await reg.register(
+            session_id="s2", requester_agent_id="agent-a", request=_req("s2")
+        )
+
+        await reg.cancel_session("s1")
+
+        d_a = await reg.wait_for_decision(aid_s1_a, timeout=0.05)
+        d_b = await reg.wait_for_decision(aid_s1_b, timeout=0.05)
+        assert d_a.status is DecisionStatus.REJECTED
+        assert d_b.status is DecisionStatus.REJECTED
+
+        d_c = await reg.wait_for_decision(aid_s2, timeout=0.05)
+        assert d_c.status is DecisionStatus.TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_idempotent_for_unknown_sid(self) -> None:
+        reg = PendingApprovalRegistry()
+        await reg.cancel_session("unknown")


### PR DESCRIPTION
## Summary
- Replay Task 1.3 after the master revert.
- Add `PendingApprovalRegistry` with suspend/resume primitives and cancellation.
- This branch is replayed on top of the replayed Task 1 branch because it depends on the approval model symbols.

## Test plan
- [x] pre-push hook: host lint/mypy/format passed on cherry-pick
- [x] original focused implementation had passing `test_approval_registry.py`

Targets the replay Phase 1 base branch.
