### PR TITLE
ci: master トリガー + ubuntu-slim 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
   pull_request:
-    branches: ["master", "main"]
+    branches: ["master"]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` の `push.branches` を `["master"]` に絞り込み、`runs-on` を `ubuntu-slim` に変更。
- Universal Evaluator 実装の前提となる CI 整備 (Phase 0 / Task 0-1)。

## Test plan
- [x] Devcontainer 内で YAML を `yaml.safe_load` し parse 成功を確認
- [ ] master への次回 push で workflow がトリガーされることを Phase 0 マージ後に確認