### PR TITLE
chore(devcontainer): DEVCONTAINER=1 を ~/.bashrc に追記

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -19,3 +19,9 @@ echo "Or run manually:"
 echo "  pytest tests/ -v"
 echo "  ruff check src/ tests/"
 echo "  mypy src/"
+
+# Phase 6 の scripts/check_evaluator.sh が DEVCONTAINER=1 を要求するため、
+# devcontainer 経由で起動した bash で確実に export されるよう ~/.bashrc に追記する。
+if ! grep -qxF 'export DEVCONTAINER=1' "${HOME}/.bashrc" 2>/dev/null; then
+    echo 'export DEVCONTAINER=1' >> "${HOME}/.bashrc"
+fi


### PR DESCRIPTION
## Summary
- `.devcontainer/setup.sh` 末尾に `export DEVCONTAINER=1` を `~/.bashrc` に idempotent 追記するブロックを追加。
- Phase 6 の `scripts/check_evaluator.sh` が Devcontainer 検知に使用する変数の自動 export を担保 (設計書 §6.4)。

## Test plan
- [x] Devcontainer 内で setup.sh 2 回実行しても `~/.bashrc` 内に export が 1 行のみ
- [x] 新規 bash で `$DEVCONTAINER` が `1`