### PR TITLE
[Phase1/Task4] Devcontainer: Node.js 20 and prisma generate on setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,7 +73,7 @@
           {
             "label": "Install Dependencies",
             "type": "shell",
-            "command": "uv sync --all-extras --dev",
+            "command": "uv sync --frozen --all-extras",
             "problemMatcher": [],
             "presentation": {
               "clear": true,
@@ -83,7 +83,7 @@
           {
             "label": "Prisma Generate",
             "type": "shell",
-            "command": "prisma generate --schema=./prisma/schema.prisma",
+            "command": "uv run prisma generate --schema=./prisma/schema.prisma",
             "problemMatcher": [],
             "presentation": {
               "reveal": "always",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,12 +73,25 @@
           {
             "label": "Install Dependencies",
             "type": "shell",
-            "command": "pip install -e \".[dev,storage-postgres]\"",
+            "command": "uv sync --all-extras --dev",
             "problemMatcher": [],
             "presentation": {
               "clear": true,
               "panel": "shared"
             }
+          },
+          {
+            "label": "Prisma Generate",
+            "type": "shell",
+            "command": "prisma generate --schema=./prisma/schema.prisma",
+            "problemMatcher": [],
+            "presentation": {
+              "reveal": "always",
+              "panel": "shared"
+            },
+            "dependsOn": [
+              "Install Dependencies"
+            ]
           },
           {
             "label": "Run Tests",

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,12 +4,12 @@ set -e
 cd /workspaces/chronos-graph
 
 # Node.js (Prisma CLI 用) - GPG 署名検証を含むセキュアなインストール
-if ! command -v node >/dev/null 2>&1; then
-  NODE_MAJOR=20
+NODE_MAJOR=20
+if ! node --version 2>/dev/null | grep -q "^v${NODE_MAJOR}\."; then
   sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
   sudo mkdir -p /etc/apt/keyrings
   curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    | sudo gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     | sudo tee /etc/apt/sources.list.d/nodesource.list
   sudo apt-get update && sudo apt-get install -y nodejs

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -3,8 +3,25 @@ set -e
 
 cd /workspaces/chronos-graph
 
+# Node.js (Prisma CLI 用) - GPG 署名検証を含むセキュアなインストール
+if ! command -v node >/dev/null 2>&1; then
+  NODE_MAJOR=20
+  sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
+  sudo mkdir -p /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+    | sudo tee /etc/apt/sources.list.d/nodesource.list
+  sudo apt-get update && sudo apt-get install -y nodejs
+fi
+
 echo "Installing dependencies..."
 uv sync --frozen --all-extras
+
+# Prisma Client Python の生成 (schema.prisma → ./prisma/ パッケージ生成)
+if [ -f ./prisma/schema.prisma ]; then
+  uv run prisma generate --schema=./prisma/schema.prisma
+fi
 
 echo "Devcontainer setup complete!"
 echo ""
@@ -14,8 +31,10 @@ echo "  - Run Ruff Check"
 echo "  - Run MyPy"
 echo "  - Run Full Lint"
 echo "  - Start Infrastructure"
+echo "  - Prisma Generate"
 echo ""
 echo "Or run manually:"
 echo "  pytest tests/ -v"
 echo "  ruff check src/ tests/"
 echo "  mypy src/"
+echo "  prisma generate --schema=./prisma/schema.prisma"


### PR DESCRIPTION
## Summary
- `.devcontainer/setup.sh` に GPG 検証付き Node.js 20 インストールと `prisma generate` を追加
- `.devcontainer/devcontainer.json` の `Install Dependencies` タスクを `uv sync --all-extras --dev` に置換
- `Prisma Generate` タスクを新設

## Test plan
- [x] `bash -n .devcontainer/setup.sh` が成功
- [ ] Devcontainer 再構築で Node.js 20 がインストールされる (Phase 1 マージ後検証)
- [ ] Devcontainer 再構築で `prisma generate` が成功する (Phase 1 マージ後検証)