### PR TITLE
[Phase3/Task1] Factory: wire PrismaStorageAdapter

### DIFF
--- a/src/context_store/storage/factory.py
+++ b/src/context_store/storage/factory.py
@@ -353,6 +353,12 @@ async def _create_graph_adapter(
             read_only=read_only,
         )
 
+    if settings.storage_backend == "prisma":
+        raise ValueError(
+            "Graph adapter is not supported for storage_backend=prisma "
+            "(Neo4j Bolt cannot be tunneled over HTTPS)"
+        )
+
     raise ValueError(f"Unsupported storage_backend for graph: {settings.storage_backend!r}")
 
 

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -16,7 +16,11 @@ if importlib.util.find_spec("asyncpg") is None:
 
 from pydantic import SecretStr
 
-from context_store.storage.factory import _create_graph_adapter, create_storage
+from context_store.storage.factory import (
+    _create_graph_adapter,
+    _create_storage_adapter,
+    create_storage,
+)
 from context_store.storage.inmemory import InMemoryCacheAdapter
 from context_store.storage.protocols import CacheAdapter, GraphAdapter, StorageAdapter
 from context_store.storage.sqlite import SQLiteStorageAdapter
@@ -278,3 +282,60 @@ class TestReturnTypes:
         assert isinstance(cache_adp, CacheAdapter)
 
         await dispose_adapters(storage, graph_adp, cache_adp)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Prisma backend (mocked)
+# ---------------------------------------------------------------------------
+
+
+def _prisma_settings(monkeypatch):
+    monkeypatch.setenv("STORAGE_BACKEND", "prisma")
+    monkeypatch.setenv("PRISMA_DATABASE_URL", "prisma://accelerate.prisma-data.net/?api_key=test")
+    monkeypatch.setenv("GRAPH_ENABLED", "false")
+    # conftest.make_settings を使わず、直接 Settings をインスタンス化することで
+    # 必要な環境変数のみをセットし、他のテストケースとの分離を図る
+    # .env ファイルの読み込みを明示的に無効化して monkeypatch を優先させる
+    from context_store.config import Settings
+
+    return Settings(_env_file=None)
+
+
+class TestPrismaBackend:
+    @pytest.mark.asyncio
+    async def test_create_storage_adapter_prisma_branch(self, monkeypatch):
+        """_create_storage_adapter が prisma 分岐で PrismaStorageAdapter.create を呼ぶ."""
+        settings = _prisma_settings(monkeypatch)
+        fake_adapter = object()
+        # `prisma` extras が dev/test 依存にない CI 環境を考慮し、存在しない可能性のある
+        # モジュールは文字列で patch する
+        with patch(
+            "context_store.storage.prisma.PrismaStorageAdapter.create",
+            new=AsyncMock(return_value=fake_adapter),
+        ) as create_mock:
+            result = await _create_storage_adapter(settings, read_only=False)
+            assert result is fake_adapter
+            create_mock.assert_awaited_once_with(settings)
+
+    @pytest.mark.asyncio
+    async def test_create_storage_adapter_prisma_read_only_raises(self, monkeypatch):
+        """Prisma バックエンドで read_only=True は NotImplementedError を送出する."""
+        settings = _prisma_settings(monkeypatch)
+        with pytest.raises(NotImplementedError):
+            await _create_storage_adapter(settings, read_only=True)
+
+    @pytest.mark.asyncio
+    async def test_create_graph_adapter_prisma_raises_value_error(self, monkeypatch):
+        """Prisma バックエンドで graph_enabled=True は ValueError を送出する (二重防御)."""
+        # Settings バリデータで graph_enabled=True は弾かれるが、
+        # ここでは factory 単体の防御機構を直接テストする
+        settings = _prisma_settings(monkeypatch)
+        # graph_enabled を強制的に True に上書き (post-init validation bypass のため
+        # model_construct を使う)
+        from context_store.config import Settings
+
+        forced_settings = Settings.model_construct(
+            **{**settings.model_dump(), "graph_enabled": True}
+        )
+        with pytest.raises(ValueError, match="not supported for storage_backend=prisma"):
+            await _create_graph_adapter(forced_settings, read_only=False)


### PR DESCRIPTION
## Summary
- _create_storage_adapter に prisma 分岐を追加 (read_only=True は NotImplementedError)
- _create_graph_adapter で prisma backend + graph_enabled を ValueError で拒否 (Settings バリデータと二重化)
- \`tests/unit/test_storage_factory.py\` にテストケースを追加

## Test plan
[x] factory prisma テスト 3 件 PASS
[x] tests/unit 全体回帰なし
