### PR TITLE
[Phase3] Factory integration for PrismaStorageAdapter

### DIFF
--- a/src/context_store/storage/factory.py
+++ b/src/context_store/storage/factory.py
@@ -7,9 +7,11 @@ Routing logic
 -------------
 - STORAGE_BACKEND=sqlite  → SQLiteStorageAdapter
 - STORAGE_BACKEND=postgres → PostgresStorageAdapter
+- STORAGE_BACKEND=prisma   → PrismaStorageAdapter
 
 - GRAPH_ENABLED=true + STORAGE_BACKEND=sqlite → SQLiteGraphAdapter
 - GRAPH_ENABLED=true + STORAGE_BACKEND=postgres → Neo4jGraphAdapter (requires NEO4J_PASSWORD)
+- GRAPH_ENABLED=true + STORAGE_BACKEND=prisma   → Not supported (raises ValueError)
 - GRAPH_ENABLED=false → None
 
 - CACHE_BACKEND=inmemory → InMemoryCacheAdapter  (+ SQLiteCacheCoherenceChecker for sqlite)

--- a/src/context_store/storage/factory.py
+++ b/src/context_store/storage/factory.py
@@ -353,6 +353,12 @@ async def _create_graph_adapter(
             read_only=read_only,
         )
 
+    if settings.storage_backend == "prisma":
+        raise ValueError(
+            "Graph adapter is not supported for storage_backend=prisma "
+            "(Neo4j Bolt cannot be tunneled over HTTPS)"
+        )
+
     raise ValueError(f"Unsupported storage_backend for graph: {settings.storage_backend!r}")
 
 

--- a/tests/integration/test_orchestrator_prisma.py
+++ b/tests/integration/test_orchestrator_prisma.py
@@ -1,0 +1,39 @@
+"""Integration-level smoke test for Orchestrator with Prisma backend."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from context_store.config import Settings
+from context_store.orchestrator import create_orchestrator
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_initialization_with_prisma(monkeypatch):
+    """STORAGE_BACKEND=prisma で create_orchestrator が正常に完了することを確認する。"""
+    monkeypatch.setenv("STORAGE_BACKEND", "prisma")
+    monkeypatch.setenv("PRISMA_DATABASE_URL", "prisma://accelerate.prisma-data.net/?api_key=test")
+    monkeypatch.setenv("GRAPH_ENABLED", "false")
+
+    # .env ファイルを無視して環境変数を優先させる
+    settings = Settings(_env_file=None)
+
+    # PrismaStorageAdapter.create をモックして実接続を回避
+    mock_storage = AsyncMock()
+    # dimension チェックを通すため、get_vector_dimension が 768 を返すように設定
+    mock_storage.get_vector_dimension = AsyncMock(return_value=768)
+    mock_storage.dispose = AsyncMock()
+
+    with patch(
+        "context_store.storage.prisma.PrismaStorageAdapter.create",
+        return_value=mock_storage,
+    ) as mock_create:
+        orchestrator = await create_orchestrator(settings)
+        try:
+            assert orchestrator._storage is mock_storage
+            assert orchestrator._graph is None
+            mock_create.assert_called_once_with(settings)
+        finally:
+            await orchestrator.dispose()

--- a/tests/integration/test_orchestrator_prisma.py
+++ b/tests/integration/test_orchestrator_prisma.py
@@ -28,7 +28,7 @@ async def test_orchestrator_initialization_with_prisma(monkeypatch):
 
     with patch(
         "context_store.storage.prisma.PrismaStorageAdapter.create",
-        return_value=mock_storage,
+        new=AsyncMock(return_value=mock_storage),
     ) as mock_create:
         orchestrator = await create_orchestrator(settings)
         try:

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -16,7 +16,11 @@ if importlib.util.find_spec("asyncpg") is None:
 
 from pydantic import SecretStr
 
-from context_store.storage.factory import _create_graph_adapter, create_storage
+from context_store.storage.factory import (
+    _create_graph_adapter,
+    _create_storage_adapter,
+    create_storage,
+)
 from context_store.storage.inmemory import InMemoryCacheAdapter
 from context_store.storage.protocols import CacheAdapter, GraphAdapter, StorageAdapter
 from context_store.storage.sqlite import SQLiteStorageAdapter
@@ -278,3 +282,60 @@ class TestReturnTypes:
         assert isinstance(cache_adp, CacheAdapter)
 
         await dispose_adapters(storage, graph_adp, cache_adp)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Prisma backend (mocked)
+# ---------------------------------------------------------------------------
+
+
+def _prisma_settings(monkeypatch):
+    monkeypatch.setenv("STORAGE_BACKEND", "prisma")
+    monkeypatch.setenv("PRISMA_DATABASE_URL", "prisma://accelerate.prisma-data.net/?api_key=test")
+    monkeypatch.setenv("GRAPH_ENABLED", "false")
+    # conftest.make_settings を使わず、直接 Settings をインスタンス化することで
+    # 必要な環境変数のみをセットし、他のテストケースとの分離を図る
+    # .env ファイルの読み込みを明示的に無効化して monkeypatch を優先させる
+    from context_store.config import Settings
+
+    return Settings(_env_file=None)
+
+
+class TestPrismaBackend:
+    @pytest.mark.asyncio
+    async def test_create_storage_adapter_prisma_branch(self, monkeypatch):
+        """_create_storage_adapter が prisma 分岐で PrismaStorageAdapter.create を呼ぶ."""
+        settings = _prisma_settings(monkeypatch)
+        fake_adapter = object()
+        # `prisma` extras が dev/test 依存にない CI 環境を考慮し、存在しない可能性のある
+        # モジュールは文字列で patch する
+        with patch(
+            "context_store.storage.prisma.PrismaStorageAdapter.create",
+            new=AsyncMock(return_value=fake_adapter),
+        ) as create_mock:
+            result = await _create_storage_adapter(settings, read_only=False)
+            assert result is fake_adapter
+            create_mock.assert_awaited_once_with(settings)
+
+    @pytest.mark.asyncio
+    async def test_create_storage_adapter_prisma_read_only_raises(self, monkeypatch):
+        """Prisma バックエンドで read_only=True は NotImplementedError を送出する."""
+        settings = _prisma_settings(monkeypatch)
+        with pytest.raises(NotImplementedError):
+            await _create_storage_adapter(settings, read_only=True)
+
+    @pytest.mark.asyncio
+    async def test_create_graph_adapter_prisma_raises_value_error(self, monkeypatch):
+        """Prisma バックエンドで graph_enabled=True は ValueError を送出する (二重防御)."""
+        # Settings バリデータで graph_enabled=True は弾かれるが、
+        # ここでは factory 単体の防御機構を直接テストする
+        settings = _prisma_settings(monkeypatch)
+        # graph_enabled を強制的に True に上書き (post-init validation bypass のため
+        # model_construct を使う)
+        from context_store.config import Settings
+
+        forced_settings = Settings.model_construct(
+            **{**settings.model_dump(), "graph_enabled": True}
+        )
+        with pytest.raises(ValueError, match="not supported for storage_backend=prisma"):
+            await _create_graph_adapter(forced_settings, read_only=False)


### PR DESCRIPTION
## Summary
- Factory (\`factory.py\`) に prisma 分岐を追加し、\`PrismaStorageAdapter\` を本番ディスパッチに組み込み
- prisma + graph_enabled の組み合わせを Settings/Factory 両層で拒否
- \`tests/unit/test_storage_factory.py\` にユニットテストを追加
- \`tests/integration/test_orchestrator_prisma.py\` にスモークテストを追加

## Test plan
[x] tests/unit 全体 PASS
[x] \`pytest tests/integration/test_orchestrator_prisma.py\` PASS
[x] CI 全ジョブ green
