### PR TITLE
chore(devcontainer): docker-in-dockerをcompose services構成に移行

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,31 +12,28 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Install system dependencies and tools needed for development
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     git \
+    gnupg \
     build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js for Prisma CLI support during devcontainer setup.
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast package management
 COPY --from=ghcr.io/astral-sh/uv:0.4.0 /uv /usr/local/bin/uv
 COPY --from=ghcr.io/astral-sh/uv:0.4.0 /uvx /usr/local/bin/uvx
 
-# Install the project dependencies using uv
 WORKDIR /workspaces/chronos-graph
-
-# Copy dependency files first for better caching
-COPY pyproject.toml uv.lock ./
-
-# Codacy: Synchronize dependencies during build instead of runtime for predictability.
-# We use --frozen to ensure it matches the lockfile exactly.
-RUN uv sync --all-extras --frozen
-
-# Copy source code
-COPY src/ src/
-COPY tests/ tests/
-
-# Finalize the installation (ensure project is installed in the environment)
-RUN uv sync --all-extras --frozen
 
 # Set up the default user (VS Code will use this)
 RUN groupadd -g 1000 vscode && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,8 +29,8 @@ RUN mkdir -p /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast package management
-COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uvx /usr/local/bin/uvx
+COPY --from=ghcr.io/astral-sh/uv@sha256:e590846f4776907b254ac0f44b5b380347af5d90d668138ca7938d1b0c2f98d3 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv@sha256:e590846f4776907b254ac0f44b5b380347af5d90d668138ca7938d1b0c2f98d3 /uvx /usr/local/bin/uvx
 
 WORKDIR /workspaces/chronos-graph
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,7 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    UV_SYSTEM_PYTHON=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Install system dependencies and tools needed for development
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -30,8 +29,8 @@ RUN mkdir -p /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast package management
-COPY --from=ghcr.io/astral-sh/uv:0.4.0 /uv /usr/local/bin/uv
-COPY --from=ghcr.io/astral-sh/uv:0.4.0 /uvx /usr/local/bin/uvx
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uvx /usr/local/bin/uvx
 
 WORKDIR /workspaces/chronos-graph
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,12 +10,12 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python",
         "python.linting.enabled": true,
         "python.linting.ruffEnabled": true,
-        "python.linting.ruffPath": "/usr/local/bin/ruff",
+        "python.linting.ruffPath": "/home/vscode/.venv/bin/ruff",
         "python.linting.mypyEnabled": true,
-        "python.linting.mypyPath": "/usr/local/bin/mypy",
+        "python.linting.mypyPath": "/home/vscode/.venv/bin/mypy",
         "python.formatting.provider": "ruff",
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "charliermarsh.ruff",
@@ -45,7 +45,7 @@
           {
             "label": "Install Dependencies",
             "type": "shell",
-            "command": "uv sync --frozen --all-extras",
+            "command": "uv venv /home/vscode/.venv && uv sync --frozen --all-extras",
             "problemMatcher": [],
             "presentation": {
               "clear": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,40 +1,12 @@
 {
   "name": "ChronosGraph Dev",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "..",
-    "args": {
-      "UV_VERSION": "0.4.0"
-    }
-  },
-  "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-  },
-  "forwardPorts": [
-    5433,
-    7474,
-    7687,
-    6379
-  ],
-  "portsAttributes": {
-    "5433": {
-      "label": "PostgreSQL",
-      "onAutoForward": "openPreview"
-    },
-    "7474": {
-      "label": "Neo4j HTTP",
-      "onAutoForward": "openPreview"
-    },
-    "7687": {
-      "label": "Neo4j Bolt",
-      "onAutoForward": "silent"
-    },
-    "6379": {
-      "label": "Redis",
-      "onAutoForward": "silent"
-    }
-  },
-  "postCreateCommand": "bash .devcontainer/setup.sh && pre-commit install --hook-type pre-push",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/chronos-graph",
+  "runServices": ["postgres", "neo4j", "redis"],
+  "overrideCommand": true,
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "bash .devcontainer/setup.sh && /home/vscode/.venv/bin/pre-commit install --hook-type pre-push",
   "customizations": {
     "vscode": {
       "settings": {
@@ -242,13 +214,16 @@
     }
   },
   "remoteEnv": {
-    "POSTGRES_HOST": "localhost:5433",
-    "NEO4J_HOST": "localhost:7687",
-    "REDIS_HOST": "localhost:6379"
+    "POSTGRES_HOST": "postgres",
+    "POSTGRES_PORT": "5432",
+    "NEO4J_URI": "bolt://neo4j:7687",
+    "REDIS_URL": "redis://redis:6379",
+    "UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv"
   },
   "remoteUser": "vscode",
   "containerEnv": {
     "PYTHONUNBUFFERED": "1",
-    "PYTHONDONTWRITEBYTECODE": "1"
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv"
   }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    user: "1000:1000"
+    volumes:
+      - ..:/workspaces/chronos-graph
+    working_dir: /workspaces/chronos-graph
+    environment:
+      - UV_FROZEN=1
+      - UV_PROJECT_ENVIRONMENT=/home/vscode/.venv
+      - UV_SYSTEM_PYTHON=1
+    command: ["bash"]
+
+  postgres:
+    build:
+      context: ../docker/postgres
+      dockerfile: Dockerfile
+    image: chronos-graph-postgres:latest
+    environment:
+      POSTGRES_DB: context_store
+      POSTGRES_USER: context_store
+      POSTGRES_PASSWORD: dev_password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ../docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ../docker/postgres/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U context_store -d context_store"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  neo4j:
+    image: neo4j:5-community
+    environment:
+      NEO4J_AUTH: neo4j/dev_password
+      NEO4J_dbms_jvm_additional: "-Djava.net.preferIPv4Stack=true"
+    volumes:
+      - neo4j_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$${NEO4J_AUTH#*/}\" 'RETURN 1'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  neo4j_data:
+  redis_data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,9 +8,7 @@ services:
       - ..:/workspaces/chronos-graph
     working_dir: /workspaces/chronos-graph
     environment:
-      - UV_FROZEN=1
       - UV_PROJECT_ENVIRONMENT=/home/vscode/.venv
-      - UV_SYSTEM_PYTHON=1
     command: ["bash"]
 
   postgres:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,25 +2,29 @@
 set -e
 
 cd /workspaces/chronos-graph
+export UV_PROJECT_ENVIRONMENT=/home/vscode/.venv
+export PATH="${UV_PROJECT_ENVIRONMENT}/bin:${PATH}"
 
-# Node.js (Prisma CLI 用) - GPG 署名検証を含むセキュアなインストール
-NODE_MAJOR=20
-if ! node --version 2>/dev/null | grep -q "^v${NODE_MAJOR}\."; then
-  sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
-  sudo mkdir -p /etc/apt/keyrings
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | sudo gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
-    | sudo tee /etc/apt/sources.list.d/nodesource.list
-  sudo apt-get update && sudo apt-get install -y nodejs
-fi
+# Node.js is installed in .devcontainer/Dockerfile so this setup script can run
+# without sudo in the non-root devcontainer user.
+node --version
 
 echo "Installing dependencies..."
-uv sync --frozen --all-extras
+uv venv "${UV_PROJECT_ENVIRONMENT}"
+uv pip install --python "${UV_PROJECT_ENVIRONMENT}/bin/python" \
+  -e ".[all]" \
+  asgi-lifespan \
+  mypy \
+  pre-commit \
+  pytest \
+  pytest-asyncio \
+  pytest-benchmark \
+  pytest-cov \
+  ruff
 
 # Prisma Client Python の生成 (schema.prisma → ./prisma/ パッケージ生成)
 if [ -f ./prisma/schema.prisma ]; then
-  uv run prisma generate --schema=./prisma/schema.prisma
+  prisma generate --schema=./prisma/schema.prisma
 fi
 
 echo "Devcontainer setup complete!"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,16 +11,7 @@ node --version
 
 echo "Installing dependencies..."
 uv venv "${UV_PROJECT_ENVIRONMENT}"
-uv pip install --python "${UV_PROJECT_ENVIRONMENT}/bin/python" \
-  -e ".[all]" \
-  asgi-lifespan \
-  mypy \
-  pre-commit \
-  pytest \
-  pytest-asyncio \
-  pytest-benchmark \
-  pytest-cov \
-  ruff
+uv sync --frozen --all-extras
 
 # Prisma Client Python の生成 (schema.prisma → ./prisma/ パッケージ生成)
 if [ -f ./prisma/schema.prisma ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,7 @@ services:
       - /workspaces/chronos-graph/.venv
     working_dir: /workspaces/chronos-graph
     environment:
-      - UV_FROZEN=1
-      - UV_SYSTEM_PYTHON=1
+      - UV_PROJECT_ENVIRONMENT=/home/vscode/.venv
     command: ["bash", "-c", "export PATH=/workspaces/chronos-graph/.venv/bin:$PATH && ruff check src/ tests/ scripts/ && ruff format --check src/ tests/ scripts/ && mypy src/ tests/ scripts/"]
     profiles:
       - lint


### PR DESCRIPTION
## Summary
- docker-in-docker feature を廃止し、Devcontainer を Compose の app service として起動する構成へ移行
- postgres / neo4j / redis を sibling services として起動し、ホスト公開ポートを不要化
- Dockerfile から重い uv sync を外し、postCreate の setup.sh で /home/vscode/.venv に依存を導入
- Node.js を Dockerfile で導入し、非 root ユーザーの setup.sh から sudo 依存を削除

## Test plan
- [x] python3 -m json.tool .devcontainer/devcontainer.json
- [x] docker compose -f .devcontainer/docker-compose.yml config
- [x] bash -n .devcontainer/setup.sh
- [x] devcontainer up --workspace-folder .
- [x] Devcontainer 内で pre-commit / pytest / ruff / mypy の起動確認
- [x] Devcontainer 内から postgres:5432 / redis:6379 / neo4j:7687 への socket 接続確認