### PR TITLE
fix: Supabase検索の実装漏れを補完

### DIFF
--- a/src/context_store/retrieval/keyword_search.py
+++ b/src/context_store/retrieval/keyword_search.py
@@ -22,13 +22,19 @@ class KeywordSearch:
         self.storage_adapter = storage_adapter
         self.default_top_k = default_top_k
 
-    async def search(self, query: str, top_k: int | None = None) -> list[ScoredMemory]:
+    async def search(
+        self,
+        query: str,
+        top_k: int | None = None,
+        project: str | None = None,
+    ) -> list[ScoredMemory]:
         """
         キーワード検索を実行
 
         Args:
             query: 検索クエリ
             top_k: 返す結果の数(Noneの場合はデフォルト値)
+            project: プロジェクトフィルタ
 
         Returns:
             ScoredMemory のリスト
@@ -40,6 +46,7 @@ class KeywordSearch:
         results = await self.storage_adapter.keyword_search(
             query=query,
             top_k=top_k,
+            project=project,
         )
 
         return results

--- a/src/context_store/retrieval/pipeline.py
+++ b/src/context_store/retrieval/pipeline.py
@@ -109,10 +109,18 @@ class RetrievalPipeline:
 
         # ステップ 2: ベクトル検索とキーワード検索を並列実行
         vector_task = self._safe_search(
-            self.vector_search.search, query, top_k, strategy.vector_weight
+            self.vector_search.search,
+            query,
+            top_k,
+            strategy.vector_weight,
+            project=project,
         )
         keyword_task = self._safe_search(
-            self.keyword_search.search, query, top_k, strategy.keyword_weight
+            self.keyword_search.search,
+            query,
+            top_k,
+            strategy.keyword_weight,
+            project=project,
         )
         vector_results, keyword_results = await asyncio.gather(vector_task, keyword_task)
 
@@ -216,12 +224,13 @@ class RetrievalPipeline:
         query: str,
         top_k: int,
         weight: float,
+        **kwargs: Any,
     ) -> list[ScoredMemory]:
         """重みが 0 のソースをスキップし、例外を空リストに変換"""
         if weight <= 0:
             return []
         try:
-            results: list[ScoredMemory] = list(await search_func(query, top_k=top_k))
+            results: list[ScoredMemory] = list(await search_func(query, top_k=top_k, **kwargs))
             return results
         except asyncio.CancelledError:
             raise

--- a/src/context_store/retrieval/vector_search.py
+++ b/src/context_store/retrieval/vector_search.py
@@ -26,13 +26,19 @@ class VectorSearch:
         self.storage_adapter = storage_adapter
         self.default_top_k = default_top_k
 
-    async def search(self, query: str, top_k: int | None = None) -> list[ScoredMemory]:
+    async def search(
+        self,
+        query: str,
+        top_k: int | None = None,
+        project: str | None = None,
+    ) -> list[ScoredMemory]:
         """
         ベクトル検索を実行
 
         Args:
             query: クエリテキスト
             top_k: 返す結果の数(Noneの場合はデフォルト値)
+            project: プロジェクトフィルタ
 
         Returns:
             ScoredMemory のリスト
@@ -47,6 +53,7 @@ class VectorSearch:
         results = await self.storage_adapter.vector_search(
             embedding=embedding,
             top_k=top_k,
+            project=project,
         )
 
         return results

--- a/supabase/migrations/20260518000002_rpc_functions.sql
+++ b/supabase/migrations/20260518000002_rpc_functions.sql
@@ -14,6 +14,7 @@ RETURNS TABLE (
     memory_type        varchar,
     source_type        varchar,
     source_metadata    jsonb,
+    embedding          vector(768),
     semantic_relevance float,
     importance_score   float,
     access_count       integer,
@@ -33,7 +34,7 @@ SET search_path = public
 AS $$
     SELECT
         m.id, m.content, m.memory_type, m.source_type, m.source_metadata,
-        m.semantic_relevance, m.importance_score, m.access_count,
+        m.embedding, m.semantic_relevance, m.importance_score, m.access_count,
         m.last_accessed_at, m.created_at, m.updated_at, m.archived_at,
         m.tags, m.project, m.content_hash,
         (1 - (m.embedding <=> query_embedding))::float AS score

--- a/tests/unit/storage/test_supabase_adapter.py
+++ b/tests/unit/storage/test_supabase_adapter.py
@@ -439,6 +439,7 @@ async def test_increment_memory_access_count_invokes_rpc():
 async def test_vector_search_calls_rpc():
     client = make_mock_client()
     now = datetime.now(timezone.utc)
+    embedding = "[0.1,0.2,0.3]"
     rows: list[dict[str, Any]] = [
         {
             "id": "550e8400-e29b-41d4-a716-446655440001",
@@ -446,7 +447,7 @@ async def test_vector_search_calls_rpc():
             "memory_type": "semantic",
             "source_type": "manual",
             "source_metadata": {},
-            "embedding": None,
+            "embedding": embedding,
             "semantic_relevance": 0.5,
             "importance_score": 0.5,
             "access_count": 0,
@@ -467,6 +468,7 @@ async def test_vector_search_calls_rpc():
     assert len(results) == 1
     assert isinstance(results[0], ScoredMemory)
     assert results[0].score == 0.95
+    assert results[0].memory.embedding == [0.1, 0.2, 0.3]
 
     call_args = client.rpc.call_args
     assert call_args[0][0] == "vector_search"

--- a/tests/unit/storage/test_supabase_migrations.py
+++ b/tests/unit/storage/test_supabase_migrations.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_vector_search_rpc_returns_embedding_column() -> None:
+    sql = Path("supabase/migrations/20260518000002_rpc_functions.sql").read_text()
+
+    match = re.search(r"RETURNS TABLE\s*\((?P<columns>.*?)\)\s*LANGUAGE", sql, re.S)
+    assert match is not None
+    returns_table = match.group("columns")
+    function_body = sql.split("AS $$", 1)[1].split("$$;", 1)[0]
+
+    assert "embedding          vector" in returns_table
+    assert "m.embedding" in function_body

--- a/tests/unit/storage/test_supabase_migrations.py
+++ b/tests/unit/storage/test_supabase_migrations.py
@@ -12,5 +12,5 @@ def test_vector_search_rpc_returns_embedding_column() -> None:
     returns_table = match.group("columns")
     function_body = sql.split("AS $$", 1)[1].split("$$;", 1)[0]
 
-    assert "embedding          vector" in returns_table
+    assert re.search(r"\bembedding\s+vector\b", returns_table) is not None
     assert "m.embedding" in function_body

--- a/tests/unit/test_keyword_search.py
+++ b/tests/unit/test_keyword_search.py
@@ -56,6 +56,17 @@ class TestKeywordSearch:
         assert call_args[1]["top_k"] == 10
 
     @pytest.mark.asyncio
+    async def test_search_passes_project_to_storage(self, keyword_search, storage_adapter):
+        """project フィルタが Storage Adapter に渡されること"""
+        await keyword_search.search("query", top_k=7, project="proj-a")
+
+        storage_adapter.keyword_search.assert_awaited_once_with(
+            query="query",
+            top_k=7,
+            project="proj-a",
+        )
+
+    @pytest.mark.asyncio
     async def test_search_returns_results(self, keyword_search):
         """検索結果が返されること"""
         results = await keyword_search.search("エラー", top_k=10)

--- a/tests/unit/test_retrieval_pipeline.py
+++ b/tests/unit/test_retrieval_pipeline.py
@@ -91,3 +91,79 @@ async def test_search_filters_fused_results_by_project() -> None:
 
     assert result["total_count"] == 1
     assert [item["memory_id"] for item in result["results"]] == [str(proj_a_memory.id)]
+
+
+@pytest.mark.asyncio
+async def test_search_filters_graph_results_by_project() -> None:
+    """graph_weight > 0 のときも project フィルタで他プロジェクトの graph 結果が除外される"""
+    proj_a_memory = Memory(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        content="project a memory",
+        memory_type=MemoryType.SEMANTIC,
+        source_type=SourceType.MANUAL,
+        project="proj-a",
+    )
+    proj_a_graph_memory = Memory(
+        id=UUID("00000000-0000-0000-0000-000000000003"),
+        content="graph connected to project a",
+        memory_type=MemoryType.SEMANTIC,
+        source_type=SourceType.MANUAL,
+        project="proj-a",
+    )
+    proj_b_graph_memory = Memory(
+        id=UUID("00000000-0000-0000-0000-000000000004"),
+        content="graph connected to project b",
+        memory_type=MemoryType.SEMANTIC,
+        source_type=SourceType.MANUAL,
+        project="proj-b",
+    )
+
+    vector_search = MagicMock()
+    vector_search.search = AsyncMock(
+        return_value=[
+            ScoredMemory(memory=proj_a_memory, score=0.99, source=MemorySource.VECTOR),
+        ]
+    )
+    keyword_search = MagicMock()
+    keyword_search.search = AsyncMock(return_value=[])
+
+    async def mock_traverse(*, seed_ids, edge_types, depth):
+        return MagicMock(
+            nodes=[
+                {"id": str(proj_a_graph_memory.id), "score": 0.85},
+                {"id": str(proj_b_graph_memory.id), "score": 0.84},
+            ]
+        )
+
+    graph_traversal = MagicMock()
+    graph_traversal.traverse = AsyncMock(side_effect=mock_traverse)
+
+    storage_adapter = MagicMock()
+    storage_adapter.get_memories_batch = AsyncMock(
+        return_value=[proj_a_graph_memory, proj_b_graph_memory]
+    )
+
+    post_processor = MagicMock()
+    post_processor.process = AsyncMock(side_effect=lambda results, **_: results)
+
+    pipeline = RetrievalPipeline(
+        query_analyzer=MagicMock(),
+        vector_search=vector_search,
+        keyword_search=keyword_search,
+        graph_traversal=graph_traversal,
+        result_fusion=ResultFusion(),
+        post_processor=post_processor,
+        storage_adapter=storage_adapter,
+    )
+
+    result = await pipeline.search(
+        "query",
+        project="proj-a",
+        top_k=10,
+        strategy=SearchStrategy(vector_weight=0.5, keyword_weight=0.0, graph_weight=0.5),
+    )
+
+    assert result["total_count"] == 2
+    result_ids = {item["memory_id"] for item in result["results"]}
+    assert result_ids == {str(proj_a_memory.id), str(proj_a_graph_memory.id)}
+    assert str(proj_b_graph_memory.id) not in result_ids

--- a/tests/unit/test_retrieval_pipeline.py
+++ b/tests/unit/test_retrieval_pipeline.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+
+from context_store.models.memory import Memory, MemorySource, MemoryType, ScoredMemory, SourceType
+from context_store.models.search import SearchStrategy
+from context_store.retrieval.pipeline import RetrievalPipeline
+from context_store.retrieval.result_fusion import ResultFusion
+
+
+@pytest.mark.asyncio
+async def test_search_passes_project_to_vector_and_keyword_search() -> None:
+    vector_search = MagicMock()
+    vector_search.search = AsyncMock(return_value=[])
+    keyword_search = MagicMock()
+    keyword_search.search = AsyncMock(return_value=[])
+    graph_traversal = MagicMock()
+    graph_traversal.traverse = AsyncMock()
+    post_processor = MagicMock()
+    post_processor.process = AsyncMock(return_value=[])
+
+    pipeline = RetrievalPipeline(
+        query_analyzer=MagicMock(),
+        vector_search=vector_search,
+        keyword_search=keyword_search,
+        graph_traversal=graph_traversal,
+        result_fusion=ResultFusion(),
+        post_processor=post_processor,
+        storage_adapter=MagicMock(),
+    )
+
+    await pipeline.search(
+        "query",
+        project="proj-a",
+        top_k=7,
+        strategy=SearchStrategy(vector_weight=0.5, keyword_weight=0.5, graph_weight=0.0),
+    )
+
+    vector_search.search.assert_awaited_once_with("query", top_k=7, project="proj-a")
+    keyword_search.search.assert_awaited_once_with("query", top_k=7, project="proj-a")
+    graph_traversal.traverse.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_filters_fused_results_by_project() -> None:
+    proj_a_memory = Memory(
+        id=UUID("00000000-0000-0000-0000-000000000001"),
+        content="project a memory",
+        memory_type=MemoryType.SEMANTIC,
+        source_type=SourceType.MANUAL,
+        project="proj-a",
+    )
+    proj_b_memory = Memory(
+        id=UUID("00000000-0000-0000-0000-000000000002"),
+        content="project b memory",
+        memory_type=MemoryType.SEMANTIC,
+        source_type=SourceType.MANUAL,
+        project="proj-b",
+    )
+    vector_search = MagicMock()
+    vector_search.search = AsyncMock(
+        return_value=[
+            ScoredMemory(memory=proj_b_memory, score=0.99, source=MemorySource.VECTOR),
+            ScoredMemory(memory=proj_a_memory, score=0.98, source=MemorySource.VECTOR),
+        ]
+    )
+    keyword_search = MagicMock()
+    keyword_search.search = AsyncMock(return_value=[])
+    post_processor = MagicMock()
+    post_processor.process = AsyncMock(side_effect=lambda results, **_: results)
+
+    pipeline = RetrievalPipeline(
+        query_analyzer=MagicMock(),
+        vector_search=vector_search,
+        keyword_search=keyword_search,
+        graph_traversal=MagicMock(),
+        result_fusion=ResultFusion(),
+        post_processor=post_processor,
+        storage_adapter=MagicMock(),
+    )
+
+    result = await pipeline.search(
+        "query",
+        project="proj-a",
+        top_k=10,
+        strategy=SearchStrategy(vector_weight=0.5, keyword_weight=0.5, graph_weight=0.0),
+    )
+
+    assert result["total_count"] == 1
+    assert [item["memory_id"] for item in result["results"]] == [str(proj_a_memory.id)]

--- a/tests/unit/test_vector_search.py
+++ b/tests/unit/test_vector_search.py
@@ -91,6 +91,17 @@ class TestVectorSearch:
         assert call_args[1]["embedding"] == [0.1, 0.2, 0.3, 0.4, 0.5]
 
     @pytest.mark.asyncio
+    async def test_search_passes_project_to_storage(self, vector_search, storage_adapter):
+        """project フィルタが Storage Adapter に渡されること"""
+        await vector_search.search("query", top_k=7, project="proj-a")
+
+        storage_adapter.vector_search.assert_awaited_once_with(
+            embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+            top_k=7,
+            project="proj-a",
+        )
+
+    @pytest.mark.asyncio
     async def test_search_returns_results(self, vector_search):
         """検索結果が返されること"""
         from uuid import UUID


### PR DESCRIPTION
## Summary
- Propagate project filters from RetrievalPipeline into vector and keyword storage searches.
- Return embedding from the Supabase vector_search RPC and verify adapter parsing.
- Add regression tests for project propagation, fused project filtering, and Supabase migration shape.

## Test Plan
- uv run pytest tests/unit/test_vector_search.py tests/unit/test_keyword_search.py tests/unit/test_retrieval_pipeline.py tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py -v
- uv run ruff check src/context_store/retrieval/pipeline.py src/context_store/retrieval/vector_search.py src/context_store/retrieval/keyword_search.py tests/unit/test_retrieval_pipeline.py tests/unit/test_vector_search.py tests/unit/test_keyword_search.py tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py
- uv run ruff format --check src/context_store/retrieval/pipeline.py src/context_store/retrieval/vector_search.py src/context_store/retrieval/keyword_search.py tests/unit/test_retrieval_pipeline.py tests/unit/test_vector_search.py tests/unit/test_keyword_search.py tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py
- uv run mypy src/context_store/retrieval/pipeline.py src/context_store/retrieval/vector_search.py src/context_store/retrieval/keyword_search.py