### PR TITLE
fix(supabase): RPC仕様漏れを補完

### DIFF
--- a/docs/superpowers/plans/2026-05-18-supabase-storage-adapter.md
+++ b/docs/superpowers/plans/2026-05-18-supabase-storage-adapter.md
@@ -46,6 +46,7 @@
 | --- | --- | --- |
 | 新規 | `supabase/migrations/20260518000001_initial_schema.sql` | `memories` テーブル + B-tree/GIN/HNSW インデックス + 拡張 (vector, pg_trgm) |
 | 新規 | `supabase/migrations/20260518000002_rpc_functions.sql` | `vector_search` / `list_projects` / `increment_memory_access_count` RPC + 権限付与 |
+| 新規 | `supabase/migrations/20260519000001_get_embedding_dimension.sql` | 空テーブル起動時に schema 上の embedding 次元を取得する RPC + `service_role` 実行権限 |
 | 新規 | `src/context_store/storage/supabase.py` | `SupabaseStorageAdapter` (Protocol 実装本体) |
 | 新規 | `tests/unit/storage/test_supabase_adapter.py` | アダプタ単体テスト (AsyncMock ベース、`make_mock_*` ヘルパを同ファイル内で定義) |
 | 変更 | `pyproject.toml` | `storage-supabase` extra 追加 → 後フェーズで `storage-prisma` extra と `prisma.*` mypy override を削除 |
@@ -346,6 +347,7 @@ $$;
 
 -- ============================================================
 -- list_projects: DISTINCT project をサーバサイドで取得。
+-- archived_at では絞り込まず、全件 archived 済みの project も返す。
 -- ============================================================
 CREATE OR REPLACE FUNCTION list_projects()
 RETURNS TABLE (project text)
@@ -428,6 +430,53 @@ git push -u origin HEAD
 gh pr create --draft --base feat/supabase-adapter/phase-1-task-1.1-initial-schema \
   --title "feat(supabase): add RPC functions migration" \
   --body "Phase 1 Task 1.2. vector_search / list_projects / increment_memory_access_count RPC + service_role GRANT。Task 1.1 にスタック。"
+```
+
+### Task 1.3: 空テーブル起動時の次元取得 RPC を追加
+
+**派生元:** Task 1.1 / Task 1.2 のブランチ — `memories.embedding vector(768)` と RPC 権限付与の前提に依存するためスタック
+
+**Files:**
+- Create: `supabase/migrations/20260519000001_get_embedding_dimension.sql`
+
+- [ ] **Step 1: migration を作成**
+
+`supabase/migrations/20260519000001_get_embedding_dimension.sql` を作成し、以下を全文書き込み:
+
+```sql
+CREATE OR REPLACE FUNCTION get_embedding_dimension()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+    SELECT COALESCE(
+        (SELECT vector_dims(embedding) FROM memories WHERE embedding IS NOT NULL ORDER BY id LIMIT 1),
+        (SELECT a.atttypmod
+         FROM pg_catalog.pg_class c
+         JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relname = 'memories'
+           AND n.nspname = 'public'
+           AND a.attname = 'embedding'
+           AND a.atttypid = (SELECT oid FROM pg_catalog.pg_type WHERE typname = 'vector')
+         LIMIT 1)
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION get_embedding_dimension() TO service_role;
+```
+
+- [ ] **Step 2: 回帰テストを追加**
+
+`tests/unit/storage/test_supabase_migrations.py` に `get_embedding_dimension()` の `service_role` 権限付与を検証するテストを追加する。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add supabase/migrations/20260519000001_get_embedding_dimension.sql tests/unit/storage/test_supabase_migrations.py
+git commit -m "fix(supabase): get_embedding_dimension RPC に実行権限を付与"
 ```
 
 ---
@@ -2578,7 +2627,7 @@ git checkout -b feat/supabase-adapter/phase-6-task-6.1-docs
    supabase link --project-ref <YOUR_PROJECT_REF>
    supabase db push
    ```
-   あるいは Studio の SQL Editor から `supabase/migrations/20260518000001_initial_schema.sql` → `20260518000002_rpc_functions.sql` の順に手動実行
+   あるいは Studio の SQL Editor から `supabase/migrations/20260518000001_initial_schema.sql` → `20260518000002_rpc_functions.sql` → `20260519000001_get_embedding_dimension.sql` の順に手動実行
 3. **Settings → API** から `Project URL` と `service_role` キーを取得
 
 #### 2. 環境変数
@@ -2600,7 +2649,7 @@ LOCAL_MODEL_NAME=cl-nagoya/ruri-v3-310m
 > - 漏洩時は Supabase Dashboard > Settings > API から直ちに再生成 (rotate)
 > - クライアントからも参照する用途では **anon key + RLS ポリシー** を利用する
 
-`EMBEDDING_DIMENSION` は `supabase/migrations/20260518000001_initial_schema.sql` の `vector(768)` と一致しなければ起動時に `INVALID_STATE` で fail-fast します。次元数を変更したい場合は SQL と環境変数を同時に更新してください。
+`EMBEDDING_DIMENSION` は `supabase/migrations/20260518000001_initial_schema.sql` の `vector(768)` と一致しなければ起動時に `INVALID_STATE` で fail-fast します。空テーブル起動時は `20260519000001_get_embedding_dimension.sql` の RPC で schema 上の次元を取得します。次元数を変更したい場合は SQL と環境変数を同時に更新してください。
 
 #### 3. 依存インストール
 

--- a/docs/superpowers/specs/2026-05-18-supabase-storage-adapter-design.md
+++ b/docs/superpowers/specs/2026-05-18-supabase-storage-adapter-design.md
@@ -24,7 +24,7 @@ Supabase Data API (PostgREST) を利用したストレージアダプタへ置�
 
 ### 2.1 対象
 - 新規ファイル: `src/context_store/storage/supabase.py` (`SupabaseStorageAdapter`)
-- 新規 SQL: `supabase/migrations/20260518000001_initial_schema.sql`、`supabase/migrations/20260518000002_rpc_functions.sql`
+- 新規 SQL: `supabase/migrations/20260518000001_initial_schema.sql`、`supabase/migrations/20260518000002_rpc_functions.sql`、`supabase/migrations/20260519000001_get_embedding_dimension.sql`
 - 変更: `pyproject.toml`、`src/context_store/config.py`、`src/context_store/storage/factory.py`
 - 削除: `src/context_store/storage/prisma.py`、`prisma/schema.prisma`、関連テスト
 
@@ -56,7 +56,9 @@ Supabase Data API (PostgREST) を利用したストレージアダプタへ置�
 │  PostgREST  (/rest/v1/memories, /rest/v1/rpc/*)            │
 │  PostgreSQL + pgvector + pg_trgm                           │
 │      - memories テーブル (vector(768))                       │
-│      - RPC: vector_search, increment_memory_access_count   │
+│      - RPC: vector_search, list_projects,                  │
+│             increment_memory_access_count,                 │
+│             get_embedding_dimension                        │
 └────────────────────────────────────────────────────────────┘
 ```
 
@@ -81,7 +83,8 @@ Supabase Data API (PostgREST) を利用したストレージアダプタへ置�
 supabase/
 └── migrations/
     ├── 20260518000001_initial_schema.sql
-    └── 20260518000002_rpc_functions.sql
+    ├── 20260518000002_rpc_functions.sql
+    └── 20260519000001_get_embedding_dimension.sql
 ```
 
 ### 4.2 `20260518000001_initial_schema.sql`
@@ -190,6 +193,8 @@ $$;
 -- list_projects: DISTINCT project をサーバサイドで取得。
 -- PostgREST 単独では DISTINCT を表現できないため RPC で提供する。
 -- 大規模データ (数万〜数十万件) でも全件転送せず一意な project のみ返す。
+-- archived_at では絞り込まない。全件 archived 済みの project も
+-- stats / audit / lifecycle review の対象として一覧に残す。
 -- ============================================================
 CREATE OR REPLACE FUNCTION list_projects()
 RETURNS TABLE (project text)
@@ -239,7 +244,36 @@ GRANT EXECUTE ON FUNCTION list_projects()                         TO service_rol
 GRANT EXECUTE ON FUNCTION increment_memory_access_count(uuid)    TO service_role;
 ```
 
-### 4.4 設計上の SQL ノート
+### 4.4 `20260519000001_get_embedding_dimension.sql`
+
+`get_embedding_dimension()` は `memories` テーブルに embedding 行がまだ存在しない初回起動時でも、schema 上の `vector(768)` 次元を fail-fast 検証に使えるようにする補助 RPC である。adapter はまず既存 embedding を probe し、見つからない場合にこの RPC を呼んで宣言済み次元を取得する。
+
+```sql
+CREATE OR REPLACE FUNCTION get_embedding_dimension()
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+    SELECT COALESCE(
+        (SELECT vector_dims(embedding) FROM memories WHERE embedding IS NOT NULL ORDER BY id LIMIT 1),
+        (SELECT a.atttypmod
+         FROM pg_catalog.pg_class c
+         JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relname = 'memories'
+           AND n.nspname = 'public'
+           AND a.attname = 'embedding'
+           AND a.atttypid = (SELECT oid FROM pg_catalog.pg_type WHERE typname = 'vector')
+         LIMIT 1)
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION get_embedding_dimension() TO service_role;
+```
+
+### 4.5 設計上の SQL ノート
 - `vector_search` は `LANGUAGE sql STABLE` で副作用なし宣言（プランナ最適化）
 - `SECURITY INVOKER` で RLS 適用時に呼出元権限で実行
 - `SET search_path = public` で関数経由のスキーマ汚染攻撃を防止 (Supabase 公式推奨)
@@ -297,8 +331,8 @@ class SupabaseStorageAdapter:
           4. オプション: get_vector_dimension() で DB 実次元を取得し
              settings.embedding_dimension と照合。不一致なら StorageError(
              code='INVALID_STATE', recoverable=False) で fail-fast。
-             ただしテーブル未投入時 (= 既存 embedding がない) は None が返るので
-             スキップ。
+             ただしテーブル未投入時 (= 既存 embedding がない) は
+             get_embedding_dimension RPC で schema の vector 次元を取得する。
         """
         ...
 
@@ -354,7 +388,7 @@ async def create(cls, settings: Settings) -> "SupabaseStorageAdapter":
 | `count_by_filter(filters)` | `count="exact", head=True` | `.select("*", count="exact", head=True)...` |
 | `list_projects()` | **RPC** `list_projects` (サーバサイド DISTINCT) | `client.rpc("list_projects", {}).execute()` |
 | `increment_memory_access_count(id)` | **RPC** | `client.rpc("increment_memory_access_count", ...)` |
-| `get_vector_dimension()` | LIMIT 1 で `embedding` 長算出 | `_parse_embedding` 利用 |
+| `get_vector_dimension()` | LIMIT 1 で `embedding` 長算出、空なら **RPC** `get_embedding_dimension` | `_parse_embedding` / `client.rpc("get_embedding_dimension", {})` |
 | `dispose()` | PostgREST httpx クローズ | `client.postgrest.aclose()` |
 
 ### 5.4 エラーマッピング
@@ -672,7 +706,7 @@ mock_client.rpc.return_value.execute = AsyncMock(
 - `test_get_memories_batch_skips_invalid_uuid` — 不正 UUID 含む入力 → 除外して `in_()` を呼ぶ
 - `test_delete_memory_returns_false_when_not_found` — `delete()` 戻りの `data=[]` → `False`
 - `test_list_by_filter_archived_logic` — `archived=None/True/False` の各ケースで WHERE 句相当の呼出が変わる
-- `test_list_projects_invokes_rpc` — `client.rpc("list_projects", {})` で呼ばれ、`data=[{"project":"a"},{"project":"b"}]` → `["a","b"]`。Python 側での set 化は不要 (RPC がサーバサイド DISTINCT)
+- `test_list_projects_invokes_rpc` — `client.rpc("list_projects", {})` で呼ばれ、`data=[{"project":"a"},{"project":"b"}]` → `["a","b"]`。Python 側での set 化は不要 (RPC がサーバサイド DISTINCT)。`list_projects()` は `archived_at` で絞り込まず、全件 archived 済みの project も返す
 
 ### 7.2 静的検証
 - `mypy --strict` を `src/context_store/storage/supabase.py` で実行

--- a/supabase/migrations/20260518000002_rpc_functions.sql
+++ b/supabase/migrations/20260518000002_rpc_functions.sql
@@ -59,7 +59,6 @@ AS $$
     SELECT DISTINCT m.project
     FROM memories m
     WHERE m.project IS NOT NULL AND m.project <> ''
-      AND m.archived_at IS NULL
     ORDER BY m.project;
 $$;
 

--- a/supabase/migrations/20260518000002_rpc_functions.sql
+++ b/supabase/migrations/20260518000002_rpc_functions.sql
@@ -2,6 +2,9 @@
 -- vector_search: pgvector の <=> (cosine distance) を使って
 -- 上位 K 件取得。score = 1 - distance でコサイン類似度を返す。
 -- p_project が NULL なら全プロジェクト対象。
+-- 注意: この関数では m.archived_at IS NULL を持つ行のみを対象とする。
+-- list_projects() はアーカイブ済みメモリを含む全プロジェクトを
+-- 返すため、両者間にフィルタ非対称性がある。これは意図的。
 -- ============================================================
 CREATE OR REPLACE FUNCTION vector_search(
     query_embedding vector(768),

--- a/supabase/migrations/20260519000001_get_embedding_dimension.sql
+++ b/supabase/migrations/20260519000001_get_embedding_dimension.sql
@@ -18,3 +18,5 @@ AS $$
          LIMIT 1)
     );
 $$;
+
+GRANT EXECUTE ON FUNCTION get_embedding_dimension() TO service_role;

--- a/tests/unit/storage/test_supabase_adapter.py
+++ b/tests/unit/storage/test_supabase_adapter.py
@@ -411,14 +411,17 @@ async def test_delete_memory_returns_false_when_not_found():
 
 
 @pytest.mark.asyncio
-async def test_list_projects_invokes_rpc():
+async def test_list_projects_returns_all_rpc_projects_including_archived_only():
     client = make_mock_client()
-    rows: list[dict[str, Any]] = [{"project": "p1"}, {"project": "p2"}]
+    rows: list[dict[str, Any]] = [
+        {"project": "active-project"},
+        {"project": "archived-only-project"},
+    ]
     client.rpc.return_value.execute = AsyncMock(return_value=make_mock_response(data=rows))
 
     adapter = SupabaseStorageAdapter(client)
     results = await adapter.list_projects()
-    assert results == ["p1", "p2"]
+    assert results == ["active-project", "archived-only-project"]
     client.rpc.assert_called_once_with("list_projects", {})
 
 

--- a/tests/unit/storage/test_supabase_adapter.py
+++ b/tests/unit/storage/test_supabase_adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import re
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -159,8 +158,20 @@ async def test_create_fails_when_dimension_mismatch():
         with pytest.raises(StorageError) as exc_info:
             await SupabaseStorageAdapter.create(settings)
     assert exc_info.value.code == "INVALID_STATE"
-    assert re.search(r"768.*1024|1024.*768", str(exc_info.value))
-    client.postgrest.aclose.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_vector_dimension_fails_when_rpc_returns_null():
+    client = make_mock_client()
+    chain = client.table.return_value.select.return_value.not_.is_.return_value.limit.return_value
+    chain.execute = AsyncMock(return_value=make_mock_response(data=[]))
+    client.rpc.return_value.execute = AsyncMock(return_value=make_mock_response(data=[]))
+
+    adapter = SupabaseStorageAdapter(client)
+    with pytest.raises(StorageError) as exc_info:
+        await adapter.get_vector_dimension()
+    assert exc_info.value.code == "INVALID_STATE"
+    client.rpc.assert_called_once_with("get_embedding_dimension", {})
 
 
 def _sample_memory(content: str = "hello world", embedding=None) -> Memory:

--- a/tests/unit/storage/test_supabase_migrations.py
+++ b/tests/unit/storage/test_supabase_migrations.py
@@ -36,8 +36,25 @@ def test_get_embedding_dimension_rpc_grants_service_role() -> None:
     sql = Path("supabase/migrations/20260519000001_get_embedding_dimension.sql").read_text()
 
     assert "CREATE OR REPLACE FUNCTION get_embedding_dimension()" in sql
-    assert re.search(
-        r"GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+get_embedding_dimension\(\)\s+TO\s+service_role",
-        sql,
-        re.I,
-    ) is not None
+    assert (
+        re.search(
+            r"GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+get_embedding_dimension\(\)\s+TO\s+service_role",
+            sql,
+            re.I,
+        )
+        is not None
+    )
+
+    # ロジック骨格の回帰検出: ORDER BY id LIMIT 1、pg_catalog 結合、型フィルタ
+    assert re.search(r"ORDER\s+BY\s+id\s+LIMIT\s+1", sql, re.I) is not None
+    assert re.search(r"pg_catalog\.pg_class", sql, re.I) is not None
+    assert re.search(r"pg_catalog\.pg_attribute", sql, re.I) is not None
+    assert re.search(r"pg_catalog\.pg_namespace", sql, re.I) is not None
+    assert (
+        re.search(
+            r"a\.atttypid\s*=\s*\(SELECT\s+oid\s+FROM\s+pg_catalog\.pg_type\s+WHERE\s+typname\s*=\s*'vector'\)",
+            sql,
+            re.I,
+        )
+        is not None
+    )

--- a/tests/unit/storage/test_supabase_migrations.py
+++ b/tests/unit/storage/test_supabase_migrations.py
@@ -14,3 +14,30 @@ def test_vector_search_rpc_returns_embedding_column() -> None:
 
     assert re.search(r"\bembedding\s+vector\b", returns_table) is not None
     assert "m.embedding" in function_body
+
+
+def test_list_projects_rpc_does_not_filter_archived_projects() -> None:
+    sql = Path("supabase/migrations/20260518000002_rpc_functions.sql").read_text()
+
+    match = re.search(
+        r"CREATE OR REPLACE FUNCTION list_projects\(\).*?AS \$\$(?P<body>.*?)\$\$;",
+        sql,
+        re.S,
+    )
+    assert match is not None
+    function_body = match.group("body")
+
+    assert "m.project IS NOT NULL" in function_body
+    assert "m.project <> ''" in function_body
+    assert re.search(r"\bm\.archived_at\s+IS\s+NULL\b", function_body, re.I) is None
+
+
+def test_get_embedding_dimension_rpc_grants_service_role() -> None:
+    sql = Path("supabase/migrations/20260519000001_get_embedding_dimension.sql").read_text()
+
+    assert "CREATE OR REPLACE FUNCTION get_embedding_dimension()" in sql
+    assert re.search(
+        r"GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+get_embedding_dimension\(\)\s+TO\s+service_role",
+        sql,
+        re.I,
+    ) is not None


### PR DESCRIPTION
## Summary
- Include archived-only projects in Supabase list_projects RPC results
- Grant service_role execute permission for get_embedding_dimension RPC
- Add regression coverage for Supabase RPC migration behavior
- Sync Supabase adapter design and implementation plan docs

## Verification
- uv run pytest tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py tests/unit/storage/test_config_supabase.py tests/unit/storage/test_factory_supabase.py -v
- uv run ruff check tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py
- uv run mypy src/
