### PR TITLE
fix(storage): delete_memory returning representation

### DIFF
--- a/src/context_store/storage/supabase.py
+++ b/src/context_store/storage/supabase.py
@@ -240,7 +240,12 @@ class SupabaseStorageAdapter:
         if not _is_valid_uuid(memory_id):
             return False
         try:
-            response = await self._client.table("memories").delete().eq("id", memory_id).execute()
+            response = (
+                await self._client.table("memories")
+                .delete(returning="representation")
+                .eq("id", memory_id)
+                .execute()
+            )
         except Exception as exc:
             raise self._map_to_storage_error(exc) from exc
         return bool(response.data)


### PR DESCRIPTION
Phase 3 Task 3.4 修正. \n\n実装漏れにより `delete_memory` が常に False を返す問題を修正しました。\n- delete() メソッドに `returning="representation"` 引数を追加しました。