### PR TITLE
feat(retrieval): RetrievalPipeline.create_for_dashboard ファクトリ追加

### DIFF
--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -743,7 +743,7 @@ gh pr create --draft \
 
 **目的:** `Orchestrator` を起動せずに dashboard 単独で `RetrievalPipeline` を組み立てる経路を確立する。`orchestrator.py:490-620` 周辺の retrieval セクション (query_analyzer / vector_search / keyword_search / graph_traversal / result_fusion / post_processor) を dashboard 用に切り出した classmethod を追加する。
 
-- [ ] **Step 1: ブランチ作成**
+- [x] **Step 1: ブランチ作成**
 
 ```bash
 git fetch origin master
@@ -752,7 +752,7 @@ git push -u origin feature/phase2_dashboard_semantic_search__base
 git checkout -b feature/phase2-task1_pipeline_factory
 ```
 
-- [ ] **Step 2: 失敗するテストを書く**
+- [x] **Step 2: 失敗するテストを書く**
 
 `tests/unit/test_retrieval_pipeline_factory.py` を新規作成:
 
@@ -792,7 +792,7 @@ async def test_create_for_dashboard_returns_pipeline_with_search() -> None:
     assert hasattr(pipeline, "search")
 ```
 
-- [ ] **Step 3: テストが失敗することを確認**
+- [x] **Step 3: テストが失敗することを確認**
 
 ```bash
 uv run pytest tests/unit/test_retrieval_pipeline_factory.py -v
@@ -800,7 +800,7 @@ uv run pytest tests/unit/test_retrieval_pipeline_factory.py -v
 
 Expected: `AttributeError: type object 'RetrievalPipeline' has no attribute 'create_for_dashboard'` で FAIL
 
-- [ ] **Step 4: `create_for_dashboard` と共有ビルダーを追加し、Orchestrator をリファクタリング**
+- [x] **Step 4: `create_for_dashboard` と共有ビルダーを追加し、Orchestrator をリファクタリング**
 
 `src/context_store/retrieval/pipeline.py` に共有ビルダー `create_from_parts` と、そのラッパー `create_for_dashboard` を追加。その後、`src/context_store/orchestrator.py` の組み立てロジックをこの共有ビルダーを使うように書き換える。
 
@@ -864,7 +864,7 @@ Expected: `AttributeError: type object 'RetrievalPipeline' has no attribute 'cre
 `retrieval_pipeline = RetrievalPipeline(...)` の直接構築箇所を `RetrievalPipeline.create_from_parts(...)` 呼び出しに置き換え。
 
 
-- [ ] **Step 5: テスト通過確認**
+- [x] **Step 5: テスト通過確認**
 
 ```bash
 uv run pytest tests/unit/test_retrieval_pipeline_factory.py -v
@@ -872,7 +872,7 @@ uv run pytest tests/unit/test_retrieval_pipeline_factory.py -v
 
 Expected: PASS
 
-- [ ] **Step 6: 既存テストへの回帰確認**
+- [x] **Step 6: 既存テストへの回帰確認**
 
 ```bash
 uv run pytest tests/unit/test_orchestrator.py tests/unit -k "retrieval or pipeline" -v
@@ -880,7 +880,7 @@ uv run pytest tests/unit/test_orchestrator.py tests/unit -k "retrieval or pipeli
 
 Expected: 既存テストが全て PASS (新規 classmethod 追加のみで既存挙動に変更なし)
 
-- [ ] **Step 7: ruff / mypy**
+- [x] **Step 7: ruff / mypy**
 
 ```bash
 uv run ruff check src/context_store/retrieval/pipeline.py src/context_store/orchestrator.py tests/unit/test_retrieval_pipeline_factory.py
@@ -889,7 +889,7 @@ uv run mypy src/context_store/retrieval/pipeline.py src/context_store/orchestrat
 
 Expected: exit 0
 
-- [ ] **Step 8: コミット**
+- [x] **Step 8: コミット**
 
 ```bash
 git add src/context_store/retrieval/pipeline.py src/context_store/orchestrator.py tests/unit/test_retrieval_pipeline_factory.py
@@ -897,7 +897,7 @@ git commit -m "feat(retrieval): add RetrievalPipeline.create_for_dashboard facto
 git push -u origin feature/phase2-task1_pipeline_factory
 ```
 
-- [ ] **Step 9: Phase Base 向け Draft PR**
+- [x] **Step 9: Phase Base 向け Draft PR**
 
 ```bash
 gh pr create --draft \

--- a/src/context_store/orchestrator.py
+++ b/src/context_store/orchestrator.py
@@ -505,13 +505,7 @@ async def create_orchestrator(
         SQLiteLifecycleStateStore,
     )
     from context_store.lifecycle.purger import Purger
-    from context_store.retrieval.graph_traversal import GraphTraversal
-    from context_store.retrieval.keyword_search import KeywordSearch
     from context_store.retrieval.pipeline import RetrievalPipeline
-    from context_store.retrieval.post_processor import PostProcessor
-    from context_store.retrieval.query_analyzer import QueryAnalyzer
-    from context_store.retrieval.result_fusion import ResultFusion
-    from context_store.retrieval.vector_search import VectorSearch
     from context_store.storage.factory import create_storage
 
     # アダプター生成
@@ -529,29 +523,11 @@ async def create_orchestrator(
             settings=settings,
         )
 
-        # RetrievalPipeline 組み立て
-        query_analyzer = QueryAnalyzer()
-        vector_search = VectorSearch(
+        retrieval_pipeline = RetrievalPipeline.create_from_parts(
+            storage=storage,
+            graph=graph,
             embedding_provider=embedding_provider,
-            storage_adapter=storage,
-        )
-        keyword_search = KeywordSearch(storage_adapter=storage)
-        graph_traversal = GraphTraversal(
-            graph_adapter=graph,
-            default_depth=settings.graph_max_logical_depth,
-            fanout_limit=settings.graph_fanout_limit,
-            max_physical_hops=settings.graph_max_physical_hops,
-        )
-        result_fusion = ResultFusion()
-        post_processor = PostProcessor(storage_adapter=storage)
-        retrieval_pipeline = RetrievalPipeline(
-            query_analyzer=query_analyzer,
-            vector_search=vector_search,
-            keyword_search=keyword_search,
-            graph_traversal=graph_traversal,
-            result_fusion=result_fusion,
-            post_processor=post_processor,
-            storage_adapter=storage,
+            settings=settings,
         )
 
         # LifecycleManager 組み立て

--- a/src/context_store/retrieval/pipeline.py
+++ b/src/context_store/retrieval/pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, TypedDict
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypedDict
 
 from context_store.models.memory import MemorySource, ScoredMemory
 from context_store.models.search import SearchStrategy
@@ -15,6 +15,11 @@ from context_store.retrieval.query_analyzer import QueryAnalyzer
 from context_store.retrieval.result_fusion import ResultFusion
 from context_store.retrieval.vector_search import VectorSearch
 from context_store.storage.protocols import StorageAdapter
+
+if TYPE_CHECKING:
+    from context_store.config import Settings
+    from context_store.embedding.protocols import EmbeddingProvider
+    from context_store.storage.protocols import GraphAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +49,53 @@ def _coerce_graph_score(raw_score: Any) -> float:
 
 class RetrievalPipeline:
     """検索パイプライン統合"""
+
+    @classmethod
+    async def create_for_dashboard(
+        cls,
+        *,
+        storage: StorageAdapter,
+        graph: GraphAdapter | None,
+        settings: Settings,
+    ) -> RetrievalPipeline:
+        """Build a RetrievalPipeline for the read-only dashboard."""
+        from context_store.embedding import create_embedding_provider
+
+        embedding_provider = create_embedding_provider(settings)
+        return cls.create_from_parts(
+            storage=storage,
+            graph=graph,
+            embedding_provider=embedding_provider,
+            settings=settings,
+        )
+
+    @classmethod
+    def create_from_parts(
+        cls,
+        *,
+        storage: StorageAdapter,
+        graph: GraphAdapter | None,
+        embedding_provider: EmbeddingProvider,
+        settings: Settings,
+    ) -> RetrievalPipeline:
+        """Shared builder used by Orchestrator and Dashboard."""
+        return cls(
+            query_analyzer=QueryAnalyzer(),
+            vector_search=VectorSearch(
+                embedding_provider=embedding_provider,
+                storage_adapter=storage,
+            ),
+            keyword_search=KeywordSearch(storage_adapter=storage),
+            graph_traversal=GraphTraversal(
+                graph_adapter=graph,
+                default_depth=settings.graph_max_logical_depth,
+                fanout_limit=settings.graph_fanout_limit,
+                max_physical_hops=settings.graph_max_physical_hops,
+            ),
+            result_fusion=ResultFusion(),
+            post_processor=PostProcessor(storage_adapter=storage),
+            storage_adapter=storage,
+        )
 
     def __init__(
         self,

--- a/src/context_store/retrieval/pipeline.py
+++ b/src/context_store/retrieval/pipeline.py
@@ -51,7 +51,7 @@ class RetrievalPipeline:
     """検索パイプライン統合"""
 
     @classmethod
-    async def create_for_dashboard(
+    def create_for_dashboard(
         cls,
         *,
         storage: StorageAdapter,

--- a/tests/unit/test_retrieval_pipeline_factory.py
+++ b/tests/unit/test_retrieval_pipeline_factory.py
@@ -1,0 +1,31 @@
+"""Ensure RetrievalPipeline.create_for_dashboard wires the minimal stack."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from context_store.retrieval.pipeline import RetrievalPipeline
+
+
+@pytest.mark.asyncio
+async def test_create_for_dashboard_returns_pipeline_with_search() -> None:
+    storage = MagicMock(name="StorageAdapter")
+    graph = MagicMock(name="GraphAdapter")
+    settings = MagicMock(
+        embedding_provider="openai",
+        openai_api_key=MagicMock(get_secret_value=MagicMock(return_value="fake-key")),
+        graph_max_logical_depth=2,
+        graph_fanout_limit=10,
+        graph_max_physical_hops=4,
+    )
+
+    with patch("context_store.embedding.create_embedding_provider") as mock_create:
+        mock_create.return_value = MagicMock()
+        pipeline = await RetrievalPipeline.create_for_dashboard(
+            storage=storage, graph=graph, settings=settings
+        )
+
+    assert isinstance(pipeline, RetrievalPipeline)
+    assert hasattr(pipeline, "search")

--- a/tests/unit/test_retrieval_pipeline_factory.py
+++ b/tests/unit/test_retrieval_pipeline_factory.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from context_store.retrieval.pipeline import RetrievalPipeline
 
 
-@pytest.mark.asyncio
-async def test_create_for_dashboard_returns_pipeline_with_search() -> None:
+def test_create_for_dashboard_returns_pipeline_with_search() -> None:
     storage = MagicMock(name="StorageAdapter")
     graph = MagicMock(name="GraphAdapter")
     settings = MagicMock(
@@ -23,7 +20,7 @@ async def test_create_for_dashboard_returns_pipeline_with_search() -> None:
 
     with patch("context_store.embedding.create_embedding_provider") as mock_create:
         mock_create.return_value = MagicMock()
-        pipeline = await RetrievalPipeline.create_for_dashboard(
+        pipeline = RetrievalPipeline.create_for_dashboard(
             storage=storage, graph=graph, settings=settings
         )
 


### PR DESCRIPTION
dashboard が Orchestrator を起動せずに RetrievalPipeline を構築できる経路を追加 (設計書 §4.6.2 改訂版)。