### PR TITLE
feat(dashboard): semantic_search サービスメソッドと schema

### DIFF
--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -743,7 +743,7 @@ gh pr create --draft \
 
 **目的:** `Orchestrator` を起動せずに dashboard 単独で `RetrievalPipeline` を組み立てる経路を確立する。`orchestrator.py:490-620` 周辺の retrieval セクション (query_analyzer / vector_search / keyword_search / graph_traversal / result_fusion / post_processor) を dashboard 用に切り出した classmethod を追加する。
 
-- [ ] **Step 1: ブランチ作成**
+- [x] **Step 1: ブランチ作成**
 
 ```bash
 git fetch origin master
@@ -752,7 +752,7 @@ git push -u origin feature/phase2_dashboard_semantic_search__base
 git checkout -b feature/phase2-task1_pipeline_factory
 ```
 
-- [ ] **Step 2: 失敗するテストを書く**
+- [x] **Step 2: 失敗するテストを書く**
 
 `tests/unit/test_retrieval_pipeline_factory.py` を新規作成:
 
@@ -792,7 +792,7 @@ async def test_create_for_dashboard_returns_pipeline_with_search() -> None:
     assert hasattr(pipeline, "search")
 ```
 
-- [ ] **Step 3: テストが失敗することを確認**
+- [x] **Step 3: テストが失敗することを確認**
 
 ```bash
 uv run pytest tests/unit/test_retrieval_pipeline_factory.py -v
@@ -1001,7 +1001,7 @@ uv run pytest tests/unit/test_dashboard_semantic_search.py -v
 
 Expected: `ImportError: cannot import name 'SemanticSearchRequest'` 等で FAIL
 
-- [ ] **Step 4: schemas.py に SemanticSearchRequest を追加**
+- [x] **Step 4: schemas.py に SemanticSearchRequest を追加**
 
 `src/context_store/dashboard/schemas.py` の末尾に追記:
 
@@ -1017,7 +1017,7 @@ class SemanticSearchRequest(DashboardBaseModel):
 
 `from pydantic import BaseModel, ConfigDict` の行を `from pydantic import BaseModel, ConfigDict, Field` に変更すれば末尾の import 行は不要。
 
-- [ ] **Step 5: services.py を修正**
+- [x] **Step 5: services.py を修正**
 
 `src/context_store/dashboard/services.py` の `DashboardService.__init__` を以下に置き換え:
 
@@ -1063,7 +1063,7 @@ if TYPE_CHECKING:
     from context_store.retrieval.pipeline import RetrievalPipeline
 ```
 
-- [ ] **Step 6: テスト通過確認**
+- [x] **Step 6: テスト通過確認**
 
 Run:
 
@@ -1073,7 +1073,7 @@ uv run pytest tests/unit/test_dashboard_semantic_search.py -v
 
 Expected: 4 テスト PASS
 
-- [ ] **Step 7: 既存 dashboard テストへの回帰確認**
+- [x] **Step 7: 既存 dashboard テストへの回帰確認**
 
 Run:
 
@@ -1083,7 +1083,7 @@ uv run pytest tests/unit/test_dashboard_service.py tests/unit/test_api_server.py
 
 Expected: 既存テスト PASS (DashboardService への新規 keyword 引数はデフォルト `None` のため互換性維持)
 
-- [ ] **Step 8: ruff / mypy**
+- [x] **Step 8: ruff / mypy**
 
 Run:
 
@@ -1094,7 +1094,7 @@ uv run mypy src/context_store/dashboard/services.py src/context_store/dashboard/
 
 Expected: exit 0
 
-- [ ] **Step 9: コミット**
+- [x] **Step 9: コミット**
 
 ```bash
 git add src/context_store/dashboard/services.py src/context_store/dashboard/schemas.py tests/unit/test_dashboard_semantic_search.py
@@ -1102,7 +1102,7 @@ git commit -m "feat(dashboard): add DashboardService.semantic_search and Semanti
 git push -u origin feature/phase2-task2_dashboard_service
 ```
 
-- [ ] **Step 10: Phase Base 向け Draft PR**
+- [x] **Step 10: Phase Base 向け Draft PR**
 
 ```bash
 gh pr create --draft \

--- a/src/context_store/dashboard/schemas.py
+++ b/src/context_store/dashboard/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
@@ -101,6 +101,12 @@ class MemorySearchRequest(DashboardBaseModel):
     min_importance: float | None = None
     limit: int = 100
     offset: int = 0
+
+
+class SemanticSearchRequest(DashboardBaseModel):
+    query: str = Field(..., min_length=1)
+    project: str | None = None
+    top_k: int = Field(default=5, ge=1, le=50)
 
 
 class GraphTraverseRequest(DashboardBaseModel):

--- a/src/context_store/dashboard/services.py
+++ b/src/context_store/dashboard/services.py
@@ -162,11 +162,14 @@ class DashboardService:
         if self._retrieval is None:
             raise RuntimeError("retrieval_pipeline not configured for this dashboard")
 
+        top_k = max(1, min(top_k, 50))
         response = await self._retrieval.search(query=query, project=project, top_k=top_k)
         memories = getattr(response, "memories", None)
         if memories is not None:
             return list(memories)
 
+        if not hasattr(response, "get"):
+            return []
         memory_ids = self._extract_memory_ids(response)
         if not memory_ids:
             return []
@@ -176,7 +179,9 @@ class DashboardService:
         return [memory_by_id[memory_id] for memory_id in memory_ids if memory_id in memory_by_id]
 
     def _extract_memory_ids(self, response: "RetrievalResponse") -> list[str]:
-        return [str(item["memory_id"]) for item in response.get("results", [])]
+        return [
+            str(item["memory_id"]) for item in response.get("results", []) if "memory_id" in item
+        ]
 
     async def get_recent_logs(self, limit: int = 100) -> list[LogEntry]:
         """Get recent system logs from the in-memory circular buffer."""

--- a/src/context_store/dashboard/services.py
+++ b/src/context_store/dashboard/services.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from context_store.dashboard.schemas import (
     DashboardStats,
@@ -18,6 +18,9 @@ from context_store.storage.protocols import (
     StorageAdapter,
 )
 
+if TYPE_CHECKING:
+    from context_store.retrieval.pipeline import RetrievalPipeline, RetrievalResponse
+
 MAX_CONCURRENT_DASHBOARD_TASKS = 5
 
 
@@ -28,9 +31,11 @@ class DashboardService:
         self,
         storage: StorageAdapter,
         graph: GraphAdapter | None,
+        retrieval_pipeline: "RetrievalPipeline | None" = None,
     ) -> None:
         self._storage = storage
         self._graph = graph
+        self._retrieval = retrieval_pipeline
 
     async def get_stats_summary(self) -> DashboardStats:
         active, archived, total, projects = await asyncio.gather(
@@ -146,6 +151,33 @@ class DashboardService:
     async def search_memories(self, filters: MemoryFilters) -> list[Memory]:
         """Search memories by filters."""
         return await self._storage.list_by_filter(filters)
+
+    async def semantic_search(
+        self,
+        query: str,
+        project: str | None = None,
+        top_k: int = 5,
+    ) -> list[Memory]:
+        """Vector similarity semantic search via the injected retrieval pipeline."""
+        if self._retrieval is None:
+            raise RuntimeError("retrieval_pipeline not configured for this dashboard")
+
+        response = await self._retrieval.search(query=query, project=project, top_k=top_k)
+        memories = getattr(response, "memories", None)
+        if memories is not None:
+            return list(memories)
+
+        memory_ids = self._extract_memory_ids(response)
+        if not memory_ids:
+            return []
+        memory_by_id = {
+            str(memory.id): memory
+            for memory in await self._storage.get_memories_batch(memory_ids)
+        }
+        return [memory_by_id[memory_id] for memory_id in memory_ids if memory_id in memory_by_id]
+
+    def _extract_memory_ids(self, response: "RetrievalResponse") -> list[str]:
+        return [str(item["memory_id"]) for item in response.get("results", [])]
 
     async def get_recent_logs(self, limit: int = 100) -> list[LogEntry]:
         """Get recent system logs from the in-memory circular buffer."""

--- a/src/context_store/dashboard/services.py
+++ b/src/context_store/dashboard/services.py
@@ -171,8 +171,7 @@ class DashboardService:
         if not memory_ids:
             return []
         memory_by_id = {
-            str(memory.id): memory
-            for memory in await self._storage.get_memories_batch(memory_ids)
+            str(memory.id): memory for memory in await self._storage.get_memories_batch(memory_ids)
         }
         return [memory_by_id[memory_id] for memory_id in memory_ids if memory_id in memory_by_id]
 

--- a/tests/unit/test_dashboard_semantic_search.py
+++ b/tests/unit/test_dashboard_semantic_search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -67,6 +68,16 @@ def test_semantic_search_request_defaults() -> None:
     assert req.top_k == 5
 
 
-def test_semantic_search_request_top_k_validation() -> None:
+@pytest.mark.parametrize(
+    "field,invalid_value",
+    [
+        ("top_k", 0),
+        ("top_k", 51),
+        ("query", ""),
+    ],
+)
+def test_semantic_search_request_validation(field: str, invalid_value: Any) -> None:
+    kwargs: dict[str, Any] = {"query": "x"}
+    kwargs[field] = invalid_value
     with pytest.raises(ValueError):
-        SemanticSearchRequest(query="x", top_k=0)
+        SemanticSearchRequest(**kwargs)

--- a/tests/unit/test_dashboard_semantic_search.py
+++ b/tests/unit/test_dashboard_semantic_search.py
@@ -1,0 +1,72 @@
+"""Tests for DashboardService.semantic_search and SemanticSearchRequest schema."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from context_store.dashboard.schemas import SemanticSearchRequest
+from context_store.dashboard.services import DashboardService
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_delegates_to_retrieval_pipeline() -> None:
+    fake_memory = SimpleNamespace(
+        id="m-1",
+        content="hello",
+        memory_type="semantic",
+        importance_score=0.8,
+        project="demo",
+        access_count=3,
+        created_at=datetime(2026, 5, 11),
+    )
+    response = SimpleNamespace(memories=[fake_memory])
+    pipeline = MagicMock()
+    pipeline.search = AsyncMock(return_value=response)
+
+    service = DashboardService(
+        storage=MagicMock(),
+        graph=None,
+        retrieval_pipeline=pipeline,
+    )
+
+    out = await service.semantic_search(query="tool:bash command=ls", project="demo", top_k=5)
+
+    pipeline.search.assert_awaited_once_with(query="tool:bash command=ls", project="demo", top_k=5)
+    assert out == [fake_memory]
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_raises_when_pipeline_not_configured() -> None:
+    service = DashboardService(storage=MagicMock(), graph=None)
+    with pytest.raises(RuntimeError, match="retrieval_pipeline"):
+        await service.semantic_search(query="anything")
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_resolves_retrieval_results_to_memories() -> None:
+    fake_memory = SimpleNamespace(id="m-1")
+    storage = MagicMock()
+    storage.get_memories_batch = AsyncMock(return_value=[fake_memory])
+    pipeline = MagicMock()
+    pipeline.search = AsyncMock(return_value={"results": [{"memory_id": "m-1"}]})
+    service = DashboardService(storage=storage, graph=None, retrieval_pipeline=pipeline)
+
+    out = await service.semantic_search(query="x")
+
+    assert out == [fake_memory]
+    storage.get_memories_batch.assert_awaited_once_with(["m-1"])
+
+
+def test_semantic_search_request_defaults() -> None:
+    req = SemanticSearchRequest(query="x")
+    assert req.project is None
+    assert req.top_k == 5
+
+
+def test_semantic_search_request_top_k_validation() -> None:
+    with pytest.raises(ValueError):
+        SemanticSearchRequest(query="x", top_k=0)


### PR DESCRIPTION
DashboardService に retrieval_pipeline 注入経路と semantic_search() を追加。既存 __init__ シグネチャはデフォルト None で互換維持 (設計書 §4.6.1)。