### PR TITLE
feat(mcp_gateway): MemoryClient (dashboard HTTP)

### DIFF
--- a/src/mcp_gateway/policy/memory_client.py
+++ b/src/mcp_gateway/policy/memory_client.py
@@ -5,6 +5,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit
 
 from mcp_gateway.policy.models_evaluator import MemoryItem
 
@@ -12,6 +13,8 @@ if TYPE_CHECKING:
     import httpx
 
 logger = logging.getLogger("chronos_evaluator.memory")
+
+_DEFAULT_ALLOWED_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 class MemoryFetchError(Exception):
@@ -24,6 +27,11 @@ class MemoryClient:
     timeout_seconds: float = 3.0
     top_k: int = 5
     _api_key: str | None = field(default=None, repr=False)
+    _allowed_hosts: frozenset[str] = field(default=_DEFAULT_ALLOWED_HOSTS, repr=False)
+
+    def __post_init__(self) -> None:
+        self.dashboard_url = self.dashboard_url.rstrip("/")
+        _validate_dashboard_url(self.dashboard_url, self._allowed_hosts)
 
     @classmethod
     def from_env(cls) -> MemoryClient | None:
@@ -31,10 +39,11 @@ class MemoryClient:
         if not url:
             return None
         return cls(
-            dashboard_url=url.rstrip("/"),
+            dashboard_url=url,
             timeout_seconds=float(os.getenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "3.0")),
             top_k=int(os.getenv("CHRONOS_DASHBOARD_TOP_K", "5")),
             _api_key=os.getenv("CHRONOS_DASHBOARD_API_KEY"),
+            _allowed_hosts=_allowed_hosts_from_env(),
         )
 
     def _build_transport(self) -> "httpx.AsyncBaseTransport | None":
@@ -59,13 +68,13 @@ class MemoryClient:
                     json={"query": query, "project": project, "top_k": self.top_k},
                     headers=headers,
                 )
+        except httpx.TimeoutException as exc:
+            raise MemoryFetchError("dashboard request timed out") from exc
         except httpx.HTTPError as exc:
-            raise MemoryFetchError(f"dashboard request failed: {exc}") from exc
+            raise MemoryFetchError(f"dashboard request failed: {type(exc).__name__}") from exc
 
         if response.status_code != 200:
-            raise MemoryFetchError(
-                f"dashboard returned {response.status_code}: {response.text[:200]}"
-            )
+            raise MemoryFetchError(f"dashboard returned status {response.status_code}")
 
         try:
             data = cast(object, response.json())
@@ -97,3 +106,23 @@ class MemoryClient:
             except (KeyError, TypeError, ValueError) as exc:
                 logger.warning("skipping malformed memory item: %s", exc)
         return items
+
+
+def _allowed_hosts_from_env() -> frozenset[str]:
+    raw = os.getenv("CHRONOS_DASHBOARD_ALLOWED_HOSTS")
+    if not raw:
+        return _DEFAULT_ALLOWED_HOSTS
+    return frozenset(host.strip().lower() for host in raw.split(",") if host.strip())
+
+
+def _validate_dashboard_url(url: str, allowed_hosts: frozenset[str]) -> None:
+    parsed = urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        raise MemoryFetchError("dashboard URL must use http or https")
+    if parsed.username or parsed.password:
+        raise MemoryFetchError("dashboard URL must not include userinfo")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise MemoryFetchError("dashboard URL must include a host")
+    if host not in allowed_hosts:
+        raise MemoryFetchError("dashboard URL host is not allowed")

--- a/src/mcp_gateway/policy/memory_client.py
+++ b/src/mcp_gateway/policy/memory_client.py
@@ -28,6 +28,7 @@ class MemoryClient:
     top_k: int = 5
     _api_key: str | None = field(default=None, repr=False)
     _allowed_hosts: frozenset[str] = field(default=_DEFAULT_ALLOWED_HOSTS, repr=False)
+    _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.dashboard_url = self.dashboard_url.rstrip("/")
@@ -46,7 +47,22 @@ class MemoryClient:
             _allowed_hosts=_allowed_hosts_from_env(),
         )
 
-    def _build_transport(self) -> "httpx.AsyncBaseTransport | None":
+    def _get_client(self) -> httpx.AsyncClient:
+        import httpx
+
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(self.timeout_seconds),
+                transport=self._build_transport(),
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _build_transport(self) -> httpx.AsyncBaseTransport | None:
         return None
 
     async def retrieve(self, query: str, project: str | None = None) -> list[MemoryItem]:
@@ -56,18 +72,14 @@ class MemoryClient:
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
-        transport = self._build_transport()
+        http = self._get_client()
 
         try:
-            async with httpx.AsyncClient(
-                timeout=httpx.Timeout(self.timeout_seconds),
-                transport=transport,
-            ) as http:
-                response = await http.post(
-                    f"{self.dashboard_url}/api/memories/semantic-search",
-                    json={"query": query, "project": project, "top_k": self.top_k},
-                    headers=headers,
-                )
+            response = await http.post(
+                f"{self.dashboard_url}/api/memories/semantic-search",
+                json={"query": query, "project": project, "top_k": self.top_k},
+                headers=headers,
+            )
         except httpx.TimeoutException as exc:
             raise MemoryFetchError("dashboard request timed out") from exc
         except httpx.HTTPError as exc:
@@ -78,7 +90,7 @@ class MemoryClient:
 
         try:
             data = cast(object, response.json())
-        except ValueError as exc:
+        except (ValueError, UnicodeDecodeError) as exc:
             raise MemoryFetchError(f"invalid JSON from dashboard: {exc}") from exc
 
         if not isinstance(data, list):
@@ -112,7 +124,8 @@ def _allowed_hosts_from_env() -> frozenset[str]:
     raw = os.getenv("CHRONOS_DASHBOARD_ALLOWED_HOSTS")
     if not raw:
         return _DEFAULT_ALLOWED_HOSTS
-    return frozenset(host.strip().lower() for host in raw.split(",") if host.strip())
+    parsed = frozenset(host.strip().lower() for host in raw.split(",") if host.strip())
+    return parsed if parsed else _DEFAULT_ALLOWED_HOSTS
 
 
 def _validate_dashboard_url(url: str, allowed_hosts: frozenset[str]) -> None:

--- a/src/mcp_gateway/policy/memory_client.py
+++ b/src/mcp_gateway/policy/memory_client.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+from mcp_gateway.policy.models_evaluator import MemoryItem
+
+if TYPE_CHECKING:
+    import httpx
+
+logger = logging.getLogger("chronos_evaluator.memory")
+
+
+class MemoryFetchError(Exception):
+    pass
+
+
+@dataclass(slots=True)
+class MemoryClient:
+    dashboard_url: str
+    timeout_seconds: float = 3.0
+    top_k: int = 5
+    _api_key: str | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_env(cls) -> MemoryClient | None:
+        url = os.getenv("CHRONOS_DASHBOARD_URL")
+        if not url:
+            return None
+        return cls(
+            dashboard_url=url.rstrip("/"),
+            timeout_seconds=float(os.getenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "3.0")),
+            top_k=int(os.getenv("CHRONOS_DASHBOARD_TOP_K", "5")),
+            _api_key=os.getenv("CHRONOS_DASHBOARD_API_KEY"),
+        )
+
+    def _build_transport(self) -> "httpx.AsyncBaseTransport | None":
+        return None
+
+    async def retrieve(self, query: str, project: str | None = None) -> list[MemoryItem]:
+        import httpx
+
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        transport = self._build_transport()
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(self.timeout_seconds),
+                transport=transport,
+            ) as http:
+                response = await http.post(
+                    f"{self.dashboard_url}/api/memories/semantic-search",
+                    json={"query": query, "project": project, "top_k": self.top_k},
+                    headers=headers,
+                )
+        except httpx.HTTPError as exc:
+            raise MemoryFetchError(f"dashboard request failed: {exc}") from exc
+
+        if response.status_code != 200:
+            raise MemoryFetchError(
+                f"dashboard returned {response.status_code}: {response.text[:200]}"
+            )
+
+        try:
+            data = cast(object, response.json())
+        except ValueError as exc:
+            raise MemoryFetchError(f"invalid JSON from dashboard: {exc}") from exc
+
+        if not isinstance(data, list):
+            raise MemoryFetchError(f"expected list, got {type(data).__name__}")
+
+        items: list[MemoryItem] = []
+        for item in cast(list[object], data):
+            if not isinstance(item, Mapping):
+                logger.warning("skipping malformed memory item: non-object")
+                continue
+            memory = cast(Mapping[str, object], item)
+            try:
+                importance_value = memory.get("importance")
+                if not isinstance(importance_value, (int, float, str)):
+                    importance_value = 0.0
+                items.append(
+                    MemoryItem(
+                        content=str(memory["content"]),
+                        memory_type=str(
+                            memory.get("memoryType") or memory.get("memory_type") or ""
+                        ),
+                        importance=float(importance_value),
+                    )
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                logger.warning("skipping malformed memory item: %s", exc)
+        return items

--- a/src/mcp_gateway/policy/memory_client.py
+++ b/src/mcp_gateway/policy/memory_client.py
@@ -39,10 +39,22 @@ class MemoryClient:
         url = os.getenv("CHRONOS_DASHBOARD_URL")
         if not url:
             return None
+
+        try:
+            timeout_seconds = float(os.getenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "3.0"))
+            if timeout_seconds <= 0:
+                raise MemoryFetchError("CHRONOS_DASHBOARD_TIMEOUT_SECONDS must be > 0")
+
+            top_k = int(os.getenv("CHRONOS_DASHBOARD_TOP_K", "5"))
+            if top_k <= 0:
+                raise MemoryFetchError("CHRONOS_DASHBOARD_TOP_K must be > 0")
+        except (ValueError, TypeError) as exc:
+            raise MemoryFetchError(f"invalid numeric value in environment: {exc}") from exc
+
         return cls(
             dashboard_url=url,
-            timeout_seconds=float(os.getenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "3.0")),
-            top_k=int(os.getenv("CHRONOS_DASHBOARD_TOP_K", "5")),
+            timeout_seconds=timeout_seconds,
+            top_k=top_k,
             _api_key=os.getenv("CHRONOS_DASHBOARD_API_KEY"),
             _allowed_hosts=_allowed_hosts_from_env(),
         )
@@ -103,15 +115,27 @@ class MemoryClient:
                 continue
             memory = cast(Mapping[str, object], item)
             try:
+                # content must be strictly str
+                content = memory.get("content")
+                if not isinstance(content, str):
+                    logger.warning("skipping malformed memory item: content must be str")
+                    continue
+
+                # memory_type should be str or None
+                raw_type = memory.get("memoryType") or memory.get("memory_type")
+                if raw_type is not None and not isinstance(raw_type, str):
+                    logger.warning("skipping malformed memory item: memory_type must be str")
+                    continue
+                memory_type = raw_type or ""
+
                 importance_value = memory.get("importance")
                 if not isinstance(importance_value, (int, float, str)):
                     importance_value = 0.0
+
                 items.append(
                     MemoryItem(
-                        content=str(memory["content"]),
-                        memory_type=str(
-                            memory.get("memoryType") or memory.get("memory_type") or ""
-                        ),
+                        content=content,
+                        memory_type=memory_type,
                         importance=float(importance_value),
                     )
                 )

--- a/src/mcp_gateway/policy/memory_client.py
+++ b/src/mcp_gateway/policy/memory_client.py
@@ -122,7 +122,10 @@ class MemoryClient:
                     continue
 
                 # memory_type should be str or None
-                raw_type = memory.get("memoryType") or memory.get("memory_type")
+                raw_type_alt = memory.get("memoryType")
+                raw_type_fallback = memory.get("memory_type")
+                raw_type = raw_type_alt if raw_type_alt is not None else raw_type_fallback
+
                 if raw_type is not None and not isinstance(raw_type, str):
                     logger.warning("skipping malformed memory item: memory_type must be str")
                     continue

--- a/tests/unit/test_mcp_gateway_memory_client.py
+++ b/tests/unit/test_mcp_gateway_memory_client.py
@@ -185,9 +185,11 @@ def test_from_env_returns_none_when_url_missing(monkeypatch: pytest.MonkeyPatch)
 
 def test_from_env_picks_up_url_and_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://localhost:9000/")
+    monkeypatch.setenv("CHRONOS_DASHBOARD_API_KEY", "expected-key")
     c = MemoryClient.from_env()
     assert c is not None
     assert c.dashboard_url == "http://localhost:9000"
+    assert c._api_key == "expected-key"
 
 
 def test_from_env_rejects_unallowed_dashboard_host(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_mcp_gateway_memory_client.py
+++ b/tests/unit/test_mcp_gateway_memory_client.py
@@ -13,7 +13,7 @@ from mcp_gateway.policy.models_evaluator import MemoryItem
 
 @pytest.mark.asyncio
 async def test_retrieve_returns_memory_items() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000", top_k=3)
+    client = MemoryClient(dashboard_url="http://localhost:9000", top_k=3)
     payload = [
         {
             "id": "1",
@@ -43,7 +43,7 @@ async def test_retrieve_returns_memory_items() -> None:
 
 @pytest.mark.asyncio
 async def test_retrieve_sends_authorization_header_when_api_key_configured() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000", _api_key="secret-token")
+    client = MemoryClient(dashboard_url="http://localhost:9000", _api_key="secret-token")
 
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.headers["authorization"] == "Bearer secret-token"
@@ -58,20 +58,21 @@ async def test_retrieve_sends_authorization_header_when_api_key_configured() -> 
 
 @pytest.mark.asyncio
 async def test_retrieve_raises_memory_fetch_error_on_http_error() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+    client = MemoryClient(dashboard_url="http://localhost:9000")
 
     async def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(503, text="pipeline missing")
+        return httpx.Response(503, text="secret should not be in exception")
 
     transport = httpx.MockTransport(handler)
     with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        with pytest.raises(MemoryFetchError):
+        with pytest.raises(MemoryFetchError) as exc_info:
             _ = await client.retrieve(query="x")
+    assert "secret should not be in exception" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio
 async def test_retrieve_raises_memory_fetch_error_on_timeout() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000", timeout_seconds=0.001)
+    client = MemoryClient(dashboard_url="http://localhost:9000", timeout_seconds=0.001)
 
     async def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.TimeoutException("boom", request=request)
@@ -84,7 +85,7 @@ async def test_retrieve_raises_memory_fetch_error_on_timeout() -> None:
 
 @pytest.mark.asyncio
 async def test_retrieve_raises_memory_fetch_error_on_invalid_json() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+    client = MemoryClient(dashboard_url="http://localhost:9000")
 
     async def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, text="not-json")
@@ -97,7 +98,7 @@ async def test_retrieve_raises_memory_fetch_error_on_invalid_json() -> None:
 
 @pytest.mark.asyncio
 async def test_retrieve_raises_memory_fetch_error_on_non_list_response() -> None:
-    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+    client = MemoryClient(dashboard_url="http://localhost:9000")
 
     async def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"content": "x"})
@@ -114,13 +115,39 @@ def test_from_env_returns_none_when_url_missing(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_from_env_picks_up_url_and_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://x:9000/")
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://localhost:9000/")
     c = MemoryClient.from_env()
     assert c is not None
-    assert c.dashboard_url == "http://x:9000"
+    assert c.dashboard_url == "http://localhost:9000"
+
+
+def test_from_env_rejects_unallowed_dashboard_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://attacker.example:9000")
+    with pytest.raises(MemoryFetchError):
+        _ = MemoryClient.from_env()
+
+
+def test_from_env_accepts_explicit_allowed_dashboard_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "https://dashboard.internal")
+    monkeypatch.setenv("CHRONOS_DASHBOARD_ALLOWED_HOSTS", "dashboard.internal")
+    c = MemoryClient.from_env()
+    assert c is not None
+    assert c.dashboard_url == "https://dashboard.internal"
+
+
+def test_rejects_dashboard_url_with_userinfo() -> None:
+    with pytest.raises(MemoryFetchError):
+        _ = MemoryClient(dashboard_url="http://token@localhost:9000")
+
+
+def test_rejects_dashboard_url_with_unsupported_scheme() -> None:
+    with pytest.raises(MemoryFetchError):
+        _ = MemoryClient(dashboard_url="file:///etc/passwd")
 
 
 def test_repr_does_not_include_api_key() -> None:
     assert "secret-token" not in repr(
-        MemoryClient(dashboard_url="http://x", _api_key="secret-token")
+        MemoryClient(dashboard_url="http://localhost", _api_key="secret-token")
     )

--- a/tests/unit/test_mcp_gateway_memory_client.py
+++ b/tests/unit/test_mcp_gateway_memory_client.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from mcp_gateway.policy.memory_client import MemoryClient, MemoryFetchError
+from mcp_gateway.policy.models_evaluator import MemoryItem
+
+
+@pytest.mark.asyncio
+async def test_retrieve_returns_memory_items() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000", top_k=3)
+    payload = [
+        {
+            "id": "1",
+            "content": "x",
+            "memoryType": "semantic",
+            "importance": 0.7,
+            "project": "demo",
+            "accessCount": 2,
+            "createdAt": None,
+        }
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/api/memories/semantic-search"
+        body = cast(object, json.loads(request.content))
+        assert body == {"query": "tool:bash command=ls", "project": "demo", "top_k": 3}
+        assert request.headers["content-type"] == "application/json"
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        out = await client.retrieve(query="tool:bash command=ls", project="demo")
+
+    assert out == [MemoryItem(content="x", memory_type="semantic", importance=0.7)]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_sends_authorization_header_when_api_key_configured() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000", _api_key="secret-token")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer secret-token"
+        return httpx.Response(200, json=[])
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        out = await client.retrieve(query="x")
+
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_memory_fetch_error_on_http_error() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="pipeline missing")
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        with pytest.raises(MemoryFetchError):
+            _ = await client.retrieve(query="x")
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_memory_fetch_error_on_timeout() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000", timeout_seconds=0.001)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("boom", request=request)
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        with pytest.raises(MemoryFetchError):
+            _ = await client.retrieve(query="x")
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_memory_fetch_error_on_invalid_json() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not-json")
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        with pytest.raises(MemoryFetchError):
+            _ = await client.retrieve(query="x")
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_memory_fetch_error_on_non_list_response() -> None:
+    client = MemoryClient(dashboard_url="http://dashboard.local:9000")
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"content": "x"})
+
+    transport = httpx.MockTransport(handler)
+    with patch.object(MemoryClient, "_build_transport", return_value=transport):
+        with pytest.raises(MemoryFetchError):
+            _ = await client.retrieve(query="x")
+
+
+def test_from_env_returns_none_when_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CHRONOS_DASHBOARD_URL", raising=False)
+    assert MemoryClient.from_env() is None
+
+
+def test_from_env_picks_up_url_and_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://x:9000/")
+    c = MemoryClient.from_env()
+    assert c is not None
+    assert c.dashboard_url == "http://x:9000"
+
+
+def test_repr_does_not_include_api_key() -> None:
+    assert "secret-token" not in repr(
+        MemoryClient(dashboard_url="http://x", _api_key="secret-token")
+    )

--- a/tests/unit/test_mcp_gateway_memory_client.py
+++ b/tests/unit/test_mcp_gateway_memory_client.py
@@ -144,6 +144,30 @@ async def test_retrieve_raises_memory_fetch_error_on_non_list_response() -> None
         await client.close()
 
 
+@pytest.mark.asyncio
+async def test_retrieve_skips_malformed_items() -> None:
+    client = MemoryClient(dashboard_url="http://localhost:9000")
+    payload = [
+        {"content": "good", "memoryType": "semantic", "importance": 0.5},
+        {"content": 123, "memoryType": "bad_content_type"},  # content must be str
+        {"content": "bad_type", "memoryType": ["not", "str"]},  # memoryType must be str
+        "not-a-mapping",
+    ]
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            out = await client.retrieve(query="x")
+    finally:
+        await client.close()
+
+    assert len(out) == 1
+    assert out[0].content == "good"
+
+
 def test_from_env_falls_back_to_default_allowed_hosts_on_empty_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -180,6 +204,26 @@ def test_from_env_accepts_explicit_allowed_dashboard_host(
     c = MemoryClient.from_env()
     assert c is not None
     assert c.dashboard_url == "https://dashboard.internal"
+
+
+def test_from_env_raises_on_invalid_numeric_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://localhost:9000")
+
+    # Invalid string
+    monkeypatch.setenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "abc")
+    with pytest.raises(MemoryFetchError, match="invalid numeric value"):
+        MemoryClient.from_env()
+
+    # Zero timeout
+    monkeypatch.setenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "0")
+    with pytest.raises(MemoryFetchError, match="must be > 0"):
+        MemoryClient.from_env()
+
+    # Negative top_k
+    monkeypatch.setenv("CHRONOS_DASHBOARD_TIMEOUT_SECONDS", "3.0")
+    monkeypatch.setenv("CHRONOS_DASHBOARD_TOP_K", "-1")
+    with pytest.raises(MemoryFetchError, match="must be > 0"):
+        MemoryClient.from_env()
 
 
 def test_rejects_dashboard_url_with_userinfo() -> None:

--- a/tests/unit/test_mcp_gateway_memory_client.py
+++ b/tests/unit/test_mcp_gateway_memory_client.py
@@ -35,8 +35,11 @@ async def test_retrieve_returns_memory_items() -> None:
         return httpx.Response(200, json=payload)
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        out = await client.retrieve(query="tool:bash command=ls", project="demo")
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            out = await client.retrieve(query="tool:bash command=ls", project="demo")
+    finally:
+        await client.close()
 
     assert out == [MemoryItem(content="x", memory_type="semantic", importance=0.7)]
 
@@ -50,24 +53,47 @@ async def test_retrieve_sends_authorization_header_when_api_key_configured() -> 
         return httpx.Response(200, json=[])
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        out = await client.retrieve(query="x")
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            out = await client.retrieve(query="x")
+    finally:
+        await client.close()
 
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_on_non_200_status() -> None:
+    client = MemoryClient(dashboard_url="http://localhost:9000")
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="service unavailable")
+
+    transport = httpx.MockTransport(handler)
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            with pytest.raises(MemoryFetchError) as exc_info:
+                _ = await client.retrieve(query="x")
+        assert "dashboard returned status 503" in str(exc_info.value)
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
 async def test_retrieve_raises_memory_fetch_error_on_http_error() -> None:
     client = MemoryClient(dashboard_url="http://localhost:9000")
 
-    async def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(503, text="secret should not be in exception")
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection failed", request=request)
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        with pytest.raises(MemoryFetchError) as exc_info:
-            _ = await client.retrieve(query="x")
-    assert "secret should not be in exception" not in str(exc_info.value)
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            with pytest.raises(MemoryFetchError) as exc_info:
+                _ = await client.retrieve(query="x")
+        assert "ConnectError" in str(exc_info.value)
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -78,9 +104,12 @@ async def test_retrieve_raises_memory_fetch_error_on_timeout() -> None:
         raise httpx.TimeoutException("boom", request=request)
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        with pytest.raises(MemoryFetchError):
-            _ = await client.retrieve(query="x")
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            with pytest.raises(MemoryFetchError):
+                _ = await client.retrieve(query="x")
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -91,9 +120,12 @@ async def test_retrieve_raises_memory_fetch_error_on_invalid_json() -> None:
         return httpx.Response(200, text="not-json")
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        with pytest.raises(MemoryFetchError):
-            _ = await client.retrieve(query="x")
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            with pytest.raises(MemoryFetchError):
+                _ = await client.retrieve(query="x")
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -104,9 +136,22 @@ async def test_retrieve_raises_memory_fetch_error_on_non_list_response() -> None
         return httpx.Response(200, json={"content": "x"})
 
     transport = httpx.MockTransport(handler)
-    with patch.object(MemoryClient, "_build_transport", return_value=transport):
-        with pytest.raises(MemoryFetchError):
-            _ = await client.retrieve(query="x")
+    try:
+        with patch.object(MemoryClient, "_build_transport", return_value=transport):
+            with pytest.raises(MemoryFetchError):
+                _ = await client.retrieve(query="x")
+    finally:
+        await client.close()
+
+
+def test_from_env_falls_back_to_default_allowed_hosts_on_empty_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CHRONOS_DASHBOARD_URL", "http://localhost:9000")
+    monkeypatch.setenv("CHRONOS_DASHBOARD_ALLOWED_HOSTS", ",")
+    c = MemoryClient.from_env()
+    assert c is not None
+    assert c._allowed_hosts == frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def test_from_env_returns_none_when_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Lazy import httpx で chronos-dashboard の /api/memories/semantic-search を叩く軽量クライアント。失敗時は MemoryFetchError (設計書 §4.5)。