### PR TITLE
feat(mcp_gateway): __main__ で evaluate サブコマンドを振り分け

### DIFF
--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -2869,7 +2869,7 @@ gh pr create --draft \
 **Files:**
 - Modify: `src/mcp_gateway/__main__.py`
 
-- [ ] **Step 1: ブランチ作成 (Task 5-1 から派生)**
+- [x] **Step 1: ブランチ作成 (Task 5-1 から派生)**
 
 ```bash
 git fetch origin
@@ -2878,7 +2878,7 @@ git pull --ff-only
 git checkout -b feature/phase5-task2_main_router
 ```
 
-- [ ] **Step 2: 失敗するテストを書く**
+- [x] **Step 2: 失敗するテストを書く**
 
 `tests/unit/test_mcp_gateway_cli.py` の末尾に追記:
 
@@ -2917,7 +2917,7 @@ def test_main_defaults_to_serve_when_no_subcommand(monkeypatch) -> None:
     assert called["serve"] == 1
 ```
 
-- [ ] **Step 3: 失敗確認**
+- [x] **Step 3: 失敗確認**
 
 Run:
 
@@ -2927,7 +2927,7 @@ uv run pytest tests/unit/test_mcp_gateway_cli.py::test_main_routes_evaluate_to_c
 
 Expected: `AttributeError` で FAIL
 
-- [ ] **Step 4: __main__.py を書き換え**
+- [x] **Step 4: __main__.py を書き換え**
 
 `src/mcp_gateway/__main__.py` 全文:
 
@@ -2980,7 +2980,7 @@ if __name__ == "__main__":
     main()
 ```
 
-- [ ] **Step 5: テスト通過確認**
+- [x] **Step 5: テスト通過確認**
 
 Run:
 
@@ -2990,7 +2990,7 @@ uv run pytest tests/unit/test_mcp_gateway_cli.py -v
 
 Expected: 新規 2 テスト含め全 PASS
 
-- [ ] **Step 6: ruff / mypy / format**
+- [x] **Step 6: ruff / mypy / format**
 
 Run:
 
@@ -3002,7 +3002,7 @@ uv run mypy src/mcp_gateway/__main__.py
 
 Expected: exit 0
 
-- [ ] **Step 7: 既存 mcp_gateway テストへの回帰確認**
+- [x] **Step 7: 既存 mcp_gateway テストへの回帰確認**
 
 Run:
 
@@ -3012,7 +3012,7 @@ uv run pytest tests/unit/test_mcp_gateway.py tests/unit/test_param_constraint.py
 
 Expected: PASS
 
-- [ ] **Step 8: コミット**
+- [x] **Step 8: コミット**
 
 ```bash
 git add src/mcp_gateway/__main__.py tests/unit/test_mcp_gateway_cli.py

--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -2550,7 +2550,7 @@ gh pr create --draft \
 - Create: `src/mcp_gateway/cli.py`
 - Test: `tests/unit/test_mcp_gateway_cli.py`
 
-- [ ] **Step 1: ブランチ作成**
+- [x] **Step 1: ブランチ作成**
 
 ```bash
 git fetch origin master
@@ -2559,7 +2559,7 @@ git push -u origin feature/phase5_evaluator_cli__base
 git checkout -b feature/phase5-task1_cli_main
 ```
 
-- [ ] **Step 2: 失敗するテストを書く**
+- [x] **Step 2: 失敗するテストを書く**
 
 `tests/unit/test_mcp_gateway_cli.py`:
 
@@ -2673,7 +2673,7 @@ def test_main_returns_int_not_calls_sys_exit(_patch_composite) -> None:
     assert isinstance(code, int)
 ```
 
-- [ ] **Step 3: テスト失敗確認**
+- [x] **Step 3: テスト失敗確認**
 
 Run:
 
@@ -2683,7 +2683,7 @@ uv run pytest tests/unit/test_mcp_gateway_cli.py -v
 
 Expected: `ModuleNotFoundError` で FAIL
 
-- [ ] **Step 4: cli.py を実装**
+- [x] **Step 4: cli.py を実装**
 
 `src/mcp_gateway/cli.py`:
 
@@ -2820,7 +2820,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 ```
 
-- [ ] **Step 5: テスト通過確認**
+- [x] **Step 5: テスト通過確認**
 
 Run:
 
@@ -2830,7 +2830,7 @@ uv run pytest tests/unit/test_mcp_gateway_cli.py -v
 
 Expected: 全 PASS
 
-- [ ] **Step 6: ruff (T20 check) / mypy / format**
+- [x] **Step 6: ruff (T20 check) / mypy / format**
 
 Run:
 
@@ -2842,7 +2842,7 @@ uv run mypy src/mcp_gateway/cli.py
 
 Expected: exit 0 (特に `print()` が含まれていれば T201 で fail するため、それを検出して修正)
 
-- [ ] **Step 7: コミット**
+- [x] **Step 7: コミット**
 
 ```bash
 git add src/mcp_gateway/cli.py tests/unit/test_mcp_gateway_cli.py

--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -2850,7 +2850,7 @@ git commit -m "feat(mcp_gateway): add evaluate CLI with stdout-purity guarantees
 git push -u origin feature/phase5-task1_cli_main
 ```
 
-- [ ] **Step 8: Phase Base 向け Draft PR**
+- [x] **Step 8: Phase Base 向け Draft PR**
 
 ```bash
 gh pr create --draft \

--- a/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
+++ b/docs/superpowers/plans/2026-05-11-mcp-gateway-universal-evaluator.md
@@ -3020,7 +3020,7 @@ git commit -m "feat(mcp_gateway): route 'evaluate' subcommand to cli.main"
 git push -u origin feature/phase5-task2_main_router
 ```
 
-- [ ] **Step 9: Phase Base 向け Draft PR**
+- [x] **Step 9: Phase Base 向け Draft PR**
 
 ```bash
 gh pr create --draft \

--- a/src/mcp_gateway/__main__.py
+++ b/src/mcp_gateway/__main__.py
@@ -1,4 +1,4 @@
-"""`python -m mcp_gateway` entrypoint."""
+"""`python -m mcp_gateway [evaluate|<serve>]` entrypoint with lazy routing."""
 
 from __future__ import annotations
 
@@ -6,12 +6,13 @@ import os
 import sys
 import traceback
 
-import uvicorn
 
-from mcp_gateway.audit.logger import AuditLogger
+def _serve() -> None:
+    """Default behaviour: run uvicorn HTTP server (legacy mode)."""
+    import uvicorn
 
+    from mcp_gateway.audit.logger import AuditLogger
 
-def main() -> None:
     try:
         host = os.getenv("MCP_GATEWAY_HOST", "127.0.0.1")
         port = int(os.getenv("MCP_GATEWAY_PORT", "9100"))
@@ -31,6 +32,14 @@ def main() -> None:
             stacktrace=traceback.format_exc(),
         )
         sys.exit(1)
+
+
+def main() -> None:
+    if len(sys.argv) >= 2 and sys.argv[1] == "evaluate":
+        from mcp_gateway.cli import main as cli_main
+
+        sys.exit(cli_main(sys.argv[2:]))
+    _serve()
 
 
 if __name__ == "__main__":

--- a/src/mcp_gateway/cli.py
+++ b/src/mcp_gateway/cli.py
@@ -127,7 +127,6 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     arg_values = cast(dict[str, object], vars(args))
-    arg_values = cast(dict[str, object], vars(args))
     policy_path = arg_values["policy_path"]
     if not isinstance(policy_path, Path):
         raise TypeError("--policy-path must parse to pathlib.Path")

--- a/src/mcp_gateway/cli.py
+++ b/src/mcp_gateway/cli.py
@@ -1,0 +1,141 @@
+"""Universal Evaluator CLI: `python -m mcp_gateway evaluate --json-io`.
+
+stdin から JSON を読み、CompositeEvaluator で評価し、stdout にちょうど 1 行の
+Decision JSON を書く。例外時も stdout には fallback ask JSON を必ず吐く。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import traceback
+from collections.abc import Mapping
+from pathlib import Path
+from typing import IO, Literal, cast
+
+from mcp_gateway.policy.composite import CompositeEvaluator
+from mcp_gateway.policy.engine import PolicyEngine
+from mcp_gateway.policy.llm_evaluator import LlmEvaluator
+from mcp_gateway.policy.loader import load_policy
+from mcp_gateway.policy.memory_client import MemoryClient
+from mcp_gateway.policy.models_evaluator import Decision, ToolCallInput
+
+logger = logging.getLogger("chronos_evaluator.cli")
+
+_FALLBACK_ASK = Decision(
+    decision="ask",
+    ask_message="System evaluation failed. Human confirmation required.",
+)
+
+
+def _configure_stderr_logging(level: str = "WARNING") -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    root.addHandler(handler)
+    root.setLevel(level)
+    for name in ("httpx", "httpcore", "anthropic", "asyncio"):
+        logging.getLogger(name).setLevel("WARNING")
+
+
+def _read_input(stream: IO[str]) -> ToolCallInput:
+    raw = stream.read()
+    if not raw or not raw.strip():
+        raise ValueError("empty stdin")
+    parsed = cast(object, json.loads(raw))
+    if not isinstance(parsed, Mapping):
+        raise ValueError(f"top-level must be object, got {type(parsed).__name__}")
+    data = cast(Mapping[str, object], parsed)
+    tool_name = data.get("tool_name")
+    tool_input = data.get("tool_input", {})
+    context = data.get("context", {})
+    if not isinstance(tool_name, str) or not tool_name:
+        raise ValueError("tool_name is required")
+    if not isinstance(tool_input, dict):
+        raise ValueError("tool_input must be object")
+    if not isinstance(context, dict):
+        raise ValueError("context must be object")
+    return ToolCallInput(
+        tool_name=tool_name,
+        tool_input=dict(cast(Mapping[str, object], tool_input)),
+        context=dict(cast(Mapping[str, object], context)),
+    )
+
+
+def _write_decision(decision: Decision, stream: IO[str]) -> None:
+    json.dump(decision.to_dict(), stream, ensure_ascii=False)
+    _ = stream.write("\n")
+    stream.flush()
+
+
+def _emit_fallback_ask(stream: IO[str]) -> None:
+    _write_decision(_FALLBACK_ASK, stream)
+
+
+def _fallback_mode_from_env() -> Literal["allow", "ask"]:
+    value = os.getenv("CHRONOS_EVALUATOR_FALLBACK", "allow")
+    if value == "ask":
+        return "ask"
+    return "allow"
+
+
+def _build_composite_evaluator(policy_path: Path) -> CompositeEvaluator:
+    policy = load_policy(policy_path)
+    engine = PolicyEngine(policy)
+    return CompositeEvaluator(
+        engine=engine,
+        memory_client=MemoryClient.from_env(),
+        llm_evaluator=LlmEvaluator.from_env(),
+        default_intent=os.getenv("CHRONOS_EVALUATOR_DEFAULT_INTENT", "default"),
+        default_agent_id=os.getenv("CHRONOS_EVALUATOR_DEFAULT_AGENT_ID", "claude-code"),
+        fallback_when_llm_not_configured=_fallback_mode_from_env(),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    _configure_stderr_logging(os.getenv("CHRONOS_EVALUATOR_LOG_LEVEL", "WARNING"))
+
+    parser = argparse.ArgumentParser(prog="mcp_gateway evaluate")
+    _ = parser.add_argument(
+        "--json-io",
+        action="store_true",
+        required=True,
+        help="enable JSON I/O mode (currently the only supported mode)",
+    )
+    _ = parser.add_argument(
+        "--policy-path",
+        type=Path,
+        default=Path(os.getenv("CHRONOS_EVALUATOR_POLICY_PATH", "intents.yaml")),
+    )
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+    arg_values = cast(dict[str, object], vars(args))
+    policy_path = arg_values["policy_path"]
+    if not isinstance(policy_path, Path):
+        raise TypeError("--policy-path must parse to pathlib.Path")
+
+    try:
+        input_ = _read_input(sys.stdin)
+    except (ValueError, json.JSONDecodeError) as exc:
+        logger.warning("stdin parse failed: %s", exc)
+        _emit_fallback_ask(sys.stdout)
+        return 2
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        _emit_fallback_ask(sys.stdout)
+        return 2
+
+    try:
+        evaluator = _build_composite_evaluator(policy_path)
+        decision = asyncio.run(evaluator.evaluate(input_))
+        _write_decision(decision, sys.stdout)
+        return 0
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        _emit_fallback_ask(sys.stdout)
+        return 2

--- a/tests/unit/test_mcp_gateway_cli.py
+++ b/tests/unit/test_mcp_gateway_cli.py
@@ -1,0 +1,122 @@
+"""Tests for mcp_gateway.cli (stdin / stdout / exit codes)."""
+# pyright: reportUnusedFunction=false
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Iterator
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_gateway.cli import main
+from mcp_gateway.policy.models_evaluator import Decision
+
+PatchedComposite = tuple[MagicMock, MagicMock]
+
+
+def _run_cli_with_input(payload: str, argv: list[str] | None = None) -> tuple[int, str, str]:
+    """Run cli.main with patched stdin/stdout/stderr; return (code, stdout, stderr)."""
+    stdin = io.StringIO(payload)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch("sys.stdin", stdin), patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+        code = main(argv or ["--json-io"])
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _patch_composite() -> Iterator[PatchedComposite]:
+    """Patch CompositeEvaluator.from_env to return a mock by default."""
+    fake = MagicMock()
+    fake.evaluate = AsyncMock(return_value=Decision(decision="allow"))
+    with patch("mcp_gateway.cli._build_composite_evaluator", return_value=fake) as m:
+        yield m, fake
+
+
+def _loads_json_object(text: str) -> dict[str, object]:
+    parsed = cast(object, json.loads(text))
+    assert isinstance(parsed, dict)
+    return cast(dict[str, object], parsed)
+
+
+def test_allow_path_writes_single_line_json_and_exit_0(
+    _patch_composite: PatchedComposite,
+) -> None:
+    payload = json.dumps({"tool_name": "bash", "tool_input": {"command": "ls"}})
+    code, out, _ = _run_cli_with_input(payload)
+    assert code == 0
+    assert out.count("\n") == 1
+    assert _loads_json_object(out.strip()) == {"decision": "allow"}
+
+
+def test_deny_path_includes_reason(_patch_composite: PatchedComposite) -> None:
+    _, fake = _patch_composite
+    fake.evaluate = AsyncMock(return_value=Decision(decision="deny", reason="bad"))
+    payload = json.dumps({"tool_name": "bash", "tool_input": {"command": "rm"}})
+    code, out, _ = _run_cli_with_input(payload)
+    assert code == 0
+    assert _loads_json_object(out.strip()) == {"decision": "deny", "reason": "bad"}
+
+
+def test_ask_path_includes_message(_patch_composite: PatchedComposite) -> None:
+    _, fake = _patch_composite
+    fake.evaluate = AsyncMock(return_value=Decision(decision="ask", ask_message="confirm"))
+    payload = json.dumps({"tool_name": "bash", "tool_input": {}})
+    code, out, _ = _run_cli_with_input(payload)
+    assert code == 0
+    assert _loads_json_object(out.strip()) == {"decision": "ask", "ask_message": "confirm"}
+
+
+def test_empty_stdin_emits_fallback_ask_and_exit_2() -> None:
+    code, out, _ = _run_cli_with_input("")
+    assert code == 2
+    body = _loads_json_object(out.strip())
+    assert body["decision"] == "ask"
+    assert "System evaluation failed" in str(body["ask_message"])
+
+
+def test_invalid_json_emits_fallback_ask_and_exit_2() -> None:
+    code, out, _ = _run_cli_with_input("not-json")
+    assert code == 2
+    body = _loads_json_object(out.strip())
+    assert body["decision"] == "ask"
+
+
+def test_unexpected_exception_emits_fallback_ask_and_exit_2(
+    _patch_composite: PatchedComposite,
+) -> None:
+    _, fake = _patch_composite
+    fake.evaluate = AsyncMock(side_effect=RuntimeError("boom"))
+    payload = json.dumps({"tool_name": "bash", "tool_input": {"command": "ls"}})
+    code, out, err = _run_cli_with_input(payload)
+    assert code == 2
+    body = _loads_json_object(out.strip())
+    assert body["decision"] == "ask"
+    # traceback must go to stderr, never stdout
+    assert "Traceback" in err
+    assert "Traceback" not in out
+
+
+def test_logger_output_goes_to_stderr_only(_patch_composite: PatchedComposite) -> None:
+    # Configure a noisy logger before main(); main() must reroute it to stderr.
+    payload = json.dumps({"tool_name": "bash", "tool_input": {"command": "ls"}})
+    code, out, _ = _run_cli_with_input(payload)
+    assert code == 0
+    # Single JSON line on stdout
+    assert out.count("\n") == 1
+    # No raw log lines on stdout
+    assert "evaluator config" not in out
+
+
+def test_main_returns_int_not_calls_sys_exit(_patch_composite: PatchedComposite) -> None:
+    """main() should *return* the exit code; the __main__ shim invokes sys.exit."""
+    payload = json.dumps({"tool_name": "bash", "tool_input": {"command": "ls"}})
+    stdin = io.StringIO(payload)
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with patch("sys.stdin", stdin), patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+        code = main(["--json-io"])
+    assert isinstance(code, int)

--- a/tests/unit/test_mcp_gateway_cli.py
+++ b/tests/unit/test_mcp_gateway_cli.py
@@ -36,7 +36,6 @@ def _run_cli_with_input(
     ):
         code = main(["--json-io"] if argv is None else argv)
     return code, stdout.getvalue(), stderr.getvalue()
-    return code, stdout.getvalue(), stderr.getvalue()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_mcp_gateway_cli.py
+++ b/tests/unit/test_mcp_gateway_cli.py
@@ -120,3 +120,34 @@ def test_main_returns_int_not_calls_sys_exit(_patch_composite: PatchedComposite)
     with patch("sys.stdin", stdin), patch("sys.stdout", stdout), patch("sys.stderr", stderr):
         code = main(["--json-io"])
     assert isinstance(code, int)
+
+
+def test_main_routes_evaluate_to_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp_gateway import __main__ as gateway_main
+
+    called: dict[str, list[str]] = {}
+
+    def fake_cli_main(argv: list[str]) -> int:
+        called["argv"] = argv
+        return 0
+
+    monkeypatch.setattr("mcp_gateway.cli.main", fake_cli_main)
+    monkeypatch.setattr("sys.argv", ["mcp_gateway", "evaluate", "--json-io"])
+    with pytest.raises(SystemExit) as exc:
+        gateway_main.main()
+    assert exc.value.code == 0
+    assert called["argv"] == ["--json-io"]
+
+
+def test_main_defaults_to_serve_when_no_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mcp_gateway import __main__ as gateway_main
+
+    called = {"serve": 0}
+
+    def fake_serve() -> None:
+        called["serve"] += 1
+
+    monkeypatch.setattr(gateway_main, "_serve", fake_serve)
+    monkeypatch.setattr("sys.argv", ["mcp_gateway"])
+    gateway_main.main()
+    assert called["serve"] == 1


### PR DESCRIPTION
evaluate 経路では uvicorn / fastapi を一切 import せず、`cli.main` に委譲 (設計書 §2.1, §4.2)。