### PR TITLE
feat(mcp_gateway): EvaluatorSettings for LiteLLM evaluator

### DIFF
--- a/src/mcp_gateway/config.py
+++ b/src/mcp_gateway/config.py
@@ -95,3 +95,19 @@ class EvaluatorSettings(BaseSettings):
 
     api_key: SecretStr | None = None
     model: str = "claude-haiku-4-5-20251001"
+
+    @model_serializer(mode="wrap")
+    def _mask_secrets(self, handler: Any, info: SerializationInfo) -> dict[str, Any]:
+        """JSON シリアライズ時のみ、SecretStr フィールドを '**********' にマスクする。"""
+        data: dict[str, Any] = handler(self)
+        if info.mode != "json":
+            return data
+
+        for field_name, field_info in self.__class__.model_fields.items():
+            if field_info.annotation is SecretStr or (
+                hasattr(field_info.annotation, "__args__")
+                and SecretStr in getattr(field_info.annotation, "__args__", ())
+            ):
+                if data.get(field_name) is not None:
+                    data[field_name] = "**********"
+        return data

--- a/src/mcp_gateway/config.py
+++ b/src/mcp_gateway/config.py
@@ -82,3 +82,16 @@ class GatewaySettings(BaseSettings):
                 if data.get(field_name) is not None:
                     data[field_name] = "**********"
         return data
+
+
+class EvaluatorSettings(BaseSettings):
+    """Universal LLM Evaluator (LiteLLM backend) の設定。"""
+
+    model_config = SettingsConfigDict(
+        env_prefix="CHRONOS_EVALUATOR_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    api_key: SecretStr | None = None
+    model: str = "claude-haiku-4-5-20251001"

--- a/tests/unit/test_mcp_gateway_evaluator_settings.py
+++ b/tests/unit/test_mcp_gateway_evaluator_settings.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from mcp_gateway.config import EvaluatorSettings
+
+
+def test_defaults_match_design(monkeypatch: pytest.MonkeyPatch) -> None:
+    """env が一切設定されていないときの既定値を検証する。"""
+    for key in ["CHRONOS_EVALUATOR_API_KEY", "CHRONOS_EVALUATOR_MODEL"]:
+        monkeypatch.delenv(key, raising=False)
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert settings.api_key is None
+    assert settings.model == "claude-haiku-4-5-20251001"
+
+
+def test_env_vars_override_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "sk-test-123")
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MODEL", "openai/gpt-4o-mini")
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert isinstance(settings.api_key, SecretStr)
+    assert settings.api_key.get_secret_value() == "sk-test-123"
+    assert settings.model == "openai/gpt-4o-mini"
+
+
+def test_api_key_is_secret_str(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SecretStr が repr で値を漏らさないことを保証する。"""
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "should-not-leak")
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert "should-not-leak" not in repr(settings)
+    assert "should-not-leak" not in str(settings)
+
+
+def test_extra_env_vars_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """数値系の CHRONOS_EVALUATOR_* env は本クラスでは読まず、ignore される。"""
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "9999")
+    monkeypatch.setenv("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", "99.9")
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert not hasattr(settings, "max_tokens")
+    assert not hasattr(settings, "timeout_seconds")

--- a/tests/unit/test_mcp_gateway_evaluator_settings.py
+++ b/tests/unit/test_mcp_gateway_evaluator_settings.py
@@ -29,12 +29,16 @@ def test_env_vars_override_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_api_key_is_secret_str(monkeypatch: pytest.MonkeyPatch) -> None:
-    """SecretStr が repr で値を漏らさないことを保証する。"""
+    """SecretStr が repr, str, model_dump(mode='json') で値を漏らさないことを保証する。"""
     monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "should-not-leak")
     settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
 
     assert "should-not-leak" not in repr(settings)
     assert "should-not-leak" not in str(settings)
+    # model_dump(mode='json') でのマスクを確認
+    dumped = settings.model_dump(mode="json")
+    assert dumped["api_key"] == "**********"
+    assert "should-not-leak" not in dumped["api_key"]
 
 
 def test_extra_env_vars_ignored(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary\n- Add `EvaluatorSettings` to `src/mcp_gateway/config.py`\n- Cover default values, env overrides, SecretStr behavior, and ignored extra env vars\n- Keep numeric evaluator settings out of this class\n\n## Verification\n- `uv run pytest tests/unit/test_mcp_gateway_evaluator_settings.py -v` ✅\n- `uv run ruff check src/mcp_gateway/config.py tests/unit/test_mcp_gateway_evaluator_settings.py` ✅\n- `uv run ruff format --check src/mcp_gateway/config.py tests/unit/test_mcp_gateway_evaluator_settings.py` ✅\n- `uv run mypy src/mcp_gateway/config.py` ✅