### PR TITLE
chore(ci): ubuntu-slim runner & master trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,16 @@ name: CI
 
 on:
   push:
-    branches: ["master", "**"]
+    branches: ["master"]
+  # NOTE: pull_request には branches フィルタを設定しない。
+  # 本リポジトリは stacked PR ワークフローを採用しており、Task 2.1 / 3.1 のような
+  # base=feature-branch の PR でも CI を必ず起動させるため、target branch を絞らない。
+  # push は master のみに限定して masters を二重実行しない。
   pull_request:
-    branches: ["master", "main"]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,6 +37,6 @@ jobs:
         run: uv run mypy src/
 
       - name: Run unit tests
-        run: uv run pytest tests/unit -v --cov=src/context_store --cov-report=term-missing
+        run: uv run pytest tests/unit -v --cov=src/context_store --cov=src/mcp_gateway --cov-report=term-missing
         env:
           OPENAI_API_KEY: sk-dummy-key-for-ci-validation


### PR DESCRIPTION
## Summary
- CI ランナーを `ubuntu-slim` に変更
- `push` トリガを `master` ブランチのみに限定
- `pull_request` トリガからは `branches` フィルタを撤去 (stacked PR で base が feature branch の PR でも CI を必ず起動させるため)
- カバレッジ対象に `src/mcp_gateway` を追加 (LiteLLM 移行後のユニットテストを計測範囲に含めるため)

## Test plan
- [ ] CI 上で `ubuntu-slim` の解決が成功すること（ジョブが起動）
- [ ] 全 lint / mypy / unit test が緑
- [ ] coverage レポートに `src/mcp_gateway` 配下の行が出現する
- [ ] 後続 Task (2.1, 3.1) の PR が base=feature-branch であっても CI が起動する

Refs: docs/superpowers/specs/2026-05-25-litellm-evaluator-refactor-design.md