### PR TITLE
feat(mcp_gateway): migrate LlmEvaluator to LiteLLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,12 @@ embedding-litellm = [
     "litellm>=1.0.0",
 ]
 evaluator = [
-    "anthropic>=0.40.0",
+    "litellm>=1.0.0",
 ]
+
 all = [
     "context-store-mcp[storage-postgres,storage-supabase,embedding-local,embedding-openai,embedding-litellm,dashboard,evaluator]",
 ]
-
 [project.scripts]
 context-store = "context_store.__main__:main"
 chronos-dashboard = "context_store.dashboard.api_server:main"

--- a/src/mcp_gateway/cli.py
+++ b/src/mcp_gateway/cli.py
@@ -61,7 +61,7 @@ def _configure_stderr_logging(level: str = "WARNING") -> None:
     except ValueError:
         gateway_logger.warning("Invalid log level %r, falling back to WARNING", level)
 
-    for name in ("httpx", "httpcore", "anthropic", "asyncio"):
+    for name in ("httpx", "httpcore", "litellm", "asyncio"):
         logging.getLogger(name).setLevel("WARNING")
 
 

--- a/src/mcp_gateway/config.py
+++ b/src/mcp_gateway/config.py
@@ -82,3 +82,16 @@ class GatewaySettings(BaseSettings):
                 if data.get(field_name) is not None:
                     data[field_name] = "**********"
         return data
+
+
+class EvaluatorSettings(BaseSettings):
+    """Universal LLM Evaluator (LiteLLM backend) の設定。"""
+
+    model_config = SettingsConfigDict(
+        env_prefix="CHRONOS_EVALUATOR_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    api_key: SecretStr | None = None
+    model: str = "claude-haiku-4-5-20251001"

--- a/src/mcp_gateway/config.py
+++ b/src/mcp_gateway/config.py
@@ -13,6 +13,22 @@ from pydantic import Field, SecretStr, SerializationInfo, field_validator, model
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+def _mask_secret_fields(instance: Any, handler: Any, info: SerializationInfo) -> dict[str, Any]:
+    """Pydantic モデルの SecretStr フィールドを '**********' にマスクする共通ヘルパー。"""
+    data: dict[str, Any] = handler(instance)
+    if info.mode != "json":
+        return data
+
+    for field_name, field_info in instance.__class__.model_fields.items():
+        if field_info.annotation is SecretStr or (
+            hasattr(field_info.annotation, "__args__")
+            and SecretStr in getattr(field_info.annotation, "__args__", ())
+        ):
+            if data.get(field_name) is not None:
+                data[field_name] = "**********"
+    return data
+
+
 class GatewaySettings(BaseSettings):
     """Runtime configuration for the MCP gateway."""
 
@@ -66,22 +82,8 @@ class GatewaySettings(BaseSettings):
 
     @model_serializer(mode="wrap")
     def _mask_secrets(self, handler: Any, info: SerializationInfo) -> dict[str, Any]:
-        """Pydantic v2 の model_dump(mode='json') で SecretStr が
-        プレーンテキスト化される問題を防ぐカスタムシリアライザ。
-        JSON シリアライズ時のみ、SecretStr フィールドを '**********' にマスクする。
-        """
-        data: dict[str, Any] = handler(self)
-        if info.mode != "json":
-            return data
-
-        for field_name, field_info in self.__class__.model_fields.items():
-            if field_info.annotation is SecretStr or (
-                hasattr(field_info.annotation, "__args__")
-                and SecretStr in getattr(field_info.annotation, "__args__", ())
-            ):
-                if data.get(field_name) is not None:
-                    data[field_name] = "**********"
-        return data
+        """JSON シリアライズ時のみ、SecretStr フィールドを '**********' にマスクする。"""
+        return _mask_secret_fields(self, handler, info)
 
 
 class EvaluatorSettings(BaseSettings):
@@ -99,15 +101,4 @@ class EvaluatorSettings(BaseSettings):
     @model_serializer(mode="wrap")
     def _mask_secrets(self, handler: Any, info: SerializationInfo) -> dict[str, Any]:
         """JSON シリアライズ時のみ、SecretStr フィールドを '**********' にマスクする。"""
-        data: dict[str, Any] = handler(self)
-        if info.mode != "json":
-            return data
-
-        for field_name, field_info in self.__class__.model_fields.items():
-            if field_info.annotation is SecretStr or (
-                hasattr(field_info.annotation, "__args__")
-                and SecretStr in getattr(field_info.annotation, "__args__", ())
-            ):
-                if data.get(field_name) is not None:
-                    data[field_name] = "**********"
-        return data
+        return _mask_secret_fields(self, handler, info)

--- a/src/mcp_gateway/policy/llm_evaluator.py
+++ b/src/mcp_gateway/policy/llm_evaluator.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import asyncio
 import importlib
 import json
 import logging
 import os
-import threading
 from collections.abc import Mapping
 from typing import Protocol, cast
 
+from mcp_gateway.config import EvaluatorSettings
 from mcp_gateway.policy.models_evaluator import (
     Decision,
     MemoryItem,
@@ -16,12 +15,9 @@ from mcp_gateway.policy.models_evaluator import (
     _redact_tool_input_for_llm,
 )
 
-logger = logging.getLogger("chronos_evaluator.llm")
+litellm = None
 
-# §2.2: LlmEvaluator._get_client uses threading.Lock to prevent race conditions
-# when multiple judge() calls attempt to initialize the client simultaneously
-# via asyncio.to_thread.
-_CLIENT_INIT_LOCK = threading.Lock()
+logger = logging.getLogger("chronos_evaluator.llm")
 
 __all__ = [
     "LlmEvaluator",
@@ -44,21 +40,63 @@ class ResponseParseError(Exception):
     pass
 
 
-class _MessagesProtocol(Protocol):
-    def create(self, **kwargs: object) -> object: ...
+class _LiteLLMProtocol(Protocol):
+    async def acompletion(self, **kwargs: object) -> object: ...
 
 
-class _AnthropicClientProtocol(Protocol):
-    messages: _MessagesProtocol
+class _ResponseMessageProtocol(Protocol):
+    content: object
 
 
-class _AnthropicFactoryProtocol(Protocol):
-    def __call__(self, *, api_key: str, timeout: object) -> _AnthropicClientProtocol: ...
+class _ChoiceProtocol(Protocol):
+    message: _ResponseMessageProtocol
 
 
-class _TextBlockProtocol(Protocol):
-    type: str
-    text: str
+class _CompletionResponseProtocol(Protocol):
+    choices: list[_ChoiceProtocol]
+
+
+def _load_litellm() -> object | None:
+    global litellm
+    if litellm is not None:
+        return litellm
+    try:
+        litellm = importlib.import_module("litellm")
+    except ImportError:
+        return None
+    return litellm
+
+
+def _parse_int_env(key: str, default: int) -> int:
+    """env を int に正規化する fail-soft ヘルパー。不正値/非正値は警告 + default。"""
+    val = os.getenv(key)
+    if val is None:
+        return default
+    try:
+        parsed = int(val)
+    except ValueError:
+        logger.warning("invalid numeric value for %s: %r; using default %d", key, val, default)
+        return default
+    if parsed <= 0:
+        logger.warning("non-positive value for %s: %r; using default %d", key, val, default)
+        return default
+    return parsed
+
+
+def _parse_float_env(key: str, default: float) -> float:
+    """env を float に正規化する fail-soft ヘルパー。不正値/非正値は警告 + default。"""
+    val = os.getenv(key)
+    if val is None:
+        return default
+    try:
+        parsed = float(val)
+    except ValueError:
+        logger.warning("invalid numeric value for %s: %r; using default %.1f", key, val, default)
+        return default
+    if parsed <= 0:
+        logger.warning("non-positive value for %s: %r; using default %.1f", key, val, default)
+        return default
+    return parsed
 
 
 SYSTEM_PROMPT = """<role>
@@ -116,7 +154,6 @@ def _parse_decision(text: str) -> Decision:
     obj = cast(Mapping[str, object], parsed)
     decision = obj.get("decision")
     if decision == "allow":
-        # §5.5: allow の場合 reason は任意。LLM が reason を返しても使用しない。
         return Decision(decision="allow")
     if decision == "deny":
         reason = obj.get("reason")
@@ -180,8 +217,6 @@ Decide now. Output JSON only."""
 
 
 def _json_for_prompt(value: object) -> str:
-    # §5.5: JSON content inside XML tags must be escaped to prevent structure breaking.
-    # We escape &, <, > and keep them as HTML entities to ensure XML safety.
     text = json.dumps(value, ensure_ascii=False)
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
@@ -199,99 +234,27 @@ class LlmEvaluator:
         api_key: str,
         model: str = "claude-haiku-4-5-20251001",
         timeout_seconds: float = 10.0,
-        thinking_budget: int = 1024,
         max_tokens: int = 1536,
     ) -> None:
-        if thinking_budget >= max_tokens:
-            raise ValueError(
-                f"thinking_budget ({thinking_budget}) must be less than max_tokens ({max_tokens})"
-            )
         self._api_key: str = api_key
         self._model: str = model
         self._timeout_seconds: float = timeout_seconds
-        self._thinking_budget: int = thinking_budget
         self._max_tokens: int = max_tokens
-        self._client: _AnthropicClientProtocol | None = None
 
     @classmethod
     def from_env(cls) -> LlmEvaluator | None:
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not api_key:
+        if _load_litellm() is None:
+            logger.warning("litellm not installed; LLM evaluator disabled")
             return None
-        try:
-            _ = importlib.import_module("anthropic")
-        except ImportError:
-            logger.warning("anthropic SDK not installed; LLM evaluator disabled")
+        settings = EvaluatorSettings()
+        if not settings.api_key:
             return None
-
-        def _parse_int_env(key: str, default: int) -> int:
-            val = os.getenv(key)
-            if val is None:
-                return default
-            try:
-                return int(val)
-            except ValueError:
-                logger.warning(
-                    "invalid numeric value for %s: %r; using default %d", key, val, default
-                )
-                return default
-
-        def _parse_float_env(key: str, default: float) -> float:
-            val = os.getenv(key)
-            if val is None:
-                return default
-            try:
-                parsed = float(val)
-                if parsed <= 0:
-                    logger.warning(
-                        "non-positive value for %s: %r; using default %.1f", key, val, default
-                    )
-                    return default
-                return parsed
-            except ValueError:
-                logger.warning(
-                    "invalid numeric value for %s: %r; using default %.1f", key, val, default
-                )
-                return default
-
-        thinking_budget = _parse_int_env("CHRONOS_EVALUATOR_THINKING_BUDGET", 1024)
-        max_tokens = _parse_int_env("CHRONOS_EVALUATOR_MAX_TOKENS", 1536)
-        timeout_seconds = _parse_float_env("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", 10.0)
-
-        # Anthropic req: thinking.budget_tokens < max_tokens
-        if thinking_budget >= max_tokens:
-            new_max = thinking_budget + 512
-            logger.warning(
-                "thinking_budget (%d) >= max_tokens (%d); bumping max_tokens to %d",
-                thinking_budget,
-                max_tokens,
-                new_max,
-            )
-            max_tokens = new_max
-
         return cls(
-            api_key=api_key,
-            model=os.getenv("CHRONOS_EVALUATOR_MODEL", "claude-haiku-4-5-20251001"),
-            timeout_seconds=timeout_seconds,
-            thinking_budget=thinking_budget,
-            max_tokens=max_tokens,
+            api_key=settings.api_key.get_secret_value(),
+            model=settings.model,
+            timeout_seconds=_parse_float_env("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", 10.0),
+            max_tokens=_parse_int_env("CHRONOS_EVALUATOR_MAX_TOKENS", 1536),
         )
-
-    def _get_client(self) -> _AnthropicClientProtocol:
-        with _CLIENT_INIT_LOCK:
-            if self._client is None:
-                import httpx
-
-                anthropic_module = importlib.import_module("anthropic")
-                anthropic_factory = cast(
-                    _AnthropicFactoryProtocol,
-                    anthropic_module.__dict__["Anthropic"],
-                )
-                self._client = anthropic_factory(
-                    api_key=self._api_key,
-                    timeout=httpx.Timeout(self._timeout_seconds, connect=2.0),
-                )
-            return self._client
 
     async def judge(
         self,
@@ -301,37 +264,42 @@ class LlmEvaluator:
         memories: list[MemoryItem],
         intent_name: str = "default",
     ) -> Decision:
+        client = _load_litellm()
+        if client is None:
+            raise LlmUnavailableError("LLM call failed: ImportError")
+        litellm_client = cast(_LiteLLMProtocol, client)
         user_prompt = _build_user_prompt(
             input_=input_, rules=rules, memories=memories, intent_name=intent_name
         )
         try:
-            response = await asyncio.to_thread(
-                self._invoke_sdk,
-                system_prompt=SYSTEM_PROMPT,
-                user_prompt=user_prompt,
+            response = await litellm_client.acompletion(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": user_prompt},
+                ],
+                max_tokens=self._max_tokens,
+                timeout=self._timeout_seconds,
+                api_key=self._api_key,
             )
         except Exception as exc:
             raise LlmUnavailableError(f"LLM call failed: {type(exc).__name__}") from exc
 
-        content = cast(list[object], getattr(response, "content", []))
-        text_blocks = [block for block in content if getattr(block, "type", None) == "text"]
-        if not text_blocks:
-            raise ResponseParseError("LLM returned no text block")
-        text = cast(_TextBlockProtocol, text_blocks[0]).text
-        return _parse_decision(text)
+        # LiteLLM の OpenAI 互換レスポンス構造は障害時に choices=[] / message 欠落 /
+        # content=None など歪んだ形で返り得る。CompositeEvaluator は
+        # (LlmUnavailableError, ResponseParseError) しか捕捉しないため、
+        # 構造アクセスの例外も必ず ResponseParseError へ変換する。
+        typed_response = cast(_CompletionResponseProtocol, response)
+        try:
+            choices = typed_response.choices
+            if not choices:
+                raise ResponseParseError("LLM returned no choices")
+            text = choices[0].message.content
+        except (AttributeError, IndexError, KeyError, TypeError) as exc:
+            raise ResponseParseError(f"unexpected response shape: {type(exc).__name__}") from exc
 
-    def _invoke_sdk(self, *, system_prompt: str, user_prompt: str) -> object:
-        client = self._get_client()
-        return client.messages.create(
-            model=self._model,
-            max_tokens=self._max_tokens,
-            system=[
-                {
-                    "type": "text",
-                    "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ],
-            messages=[{"role": "user", "content": user_prompt}],
-            thinking={"type": "enabled", "budget_tokens": self._thinking_budget},
-        )
+        if not isinstance(text, str):
+            raise ResponseParseError(f"unexpected text content type: {type(text).__name__}")
+        if not text:
+            raise ResponseParseError("LLM returned no text content")
+        return _parse_decision(text)

--- a/src/mcp_gateway/policy/models_evaluator.py
+++ b/src/mcp_gateway/policy/models_evaluator.py
@@ -1,7 +1,7 @@
 """Shared data models and redaction utilities for the Universal Evaluator.
 
 This module is imported by composite.py, llm_evaluator.py, memory_client.py,
-and cli.py. Importing it must not require any optional dependency (anthropic /
+and cli.py. Importing it must not require any optional dependency (litellm /
 httpx); only stdlib + dataclasses is allowed.
 """
 

--- a/tests/integration/test_evaluator_cli_subprocess.py
+++ b/tests/integration/test_evaluator_cli_subprocess.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
-import sys
 import textwrap
 from collections.abc import Mapping
 from pathlib import Path
@@ -59,7 +59,7 @@ def _build_env(
     env = os.environ.copy()
     env.update(
         {
-            "ANTHROPIC_API_KEY": "",
+            "CHRONOS_EVALUATOR_API_KEY": "",
             "CHRONOS_DASHBOARD_URL": "",
             "CHRONOS_EVALUATOR_FALLBACK": "allow",
             "CHRONOS_EVALUATOR_DEFAULT_INTENT": "default",
@@ -78,20 +78,15 @@ def _run_cli(
     env_overrides: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     env = _build_env(policy, env_overrides)
-    return subprocess.run(  # noqa: S603 - trusted test interpreter and fixed module args # nosec
-        [
-            sys.executable,
-            "-m",
-            "mcp_gateway",
-            "evaluate",
-            "--json-io",
-            "--policy-path",
-            str(policy),
-        ],
+    command = (
+        f"uv run python -m mcp_gateway evaluate --json-io --policy-path {shlex.quote(str(policy))}"
+    )
+    return subprocess.run(  # noqa: S603, S607
+        ["bash", "-lc", command],  # noqa: S607
         input=json.dumps(payload),
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=60,
         env=env,
         check=False,
     )
@@ -117,20 +112,16 @@ def test_cli_evaluate_deny_path(policy_path: Path) -> None:
 
 def test_cli_evaluate_invalid_stdin(policy_path: Path) -> None:
     env = _build_env(policy_path)
-    result = subprocess.run(  # noqa: S603 - trusted test interpreter and fixed module args # nosec
-        [
-            sys.executable,
-            "-m",
-            "mcp_gateway",
-            "evaluate",
-            "--json-io",
-            "--policy-path",
-            str(policy_path),
-        ],
+    command = (
+        "uv run python -m mcp_gateway evaluate --json-io --policy-path "
+        f"{shlex.quote(str(policy_path))}"
+    )
+    result = subprocess.run(  # noqa: S603, S607
+        ["bash", "-lc", command],  # noqa: S607
         input="not-json",
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=60,
         env=env,
         check=False,
     )
@@ -142,19 +133,13 @@ def test_cli_evaluate_invalid_stdin(policy_path: Path) -> None:
 
 def test_cli_evaluate_missing_json_io_still_emits_single_json_line(policy_path: Path) -> None:
     env = _build_env(policy_path)
-    result = subprocess.run(  # noqa: S603 - trusted test interpreter and fixed module args # nosec
-        [
-            sys.executable,
-            "-m",
-            "mcp_gateway",
-            "evaluate",
-            "--policy-path",
-            str(policy_path),
-        ],
+    command = f"uv run python -m mcp_gateway evaluate --policy-path {shlex.quote(str(policy_path))}"
+    result = subprocess.run(  # noqa: S603, S607
+        ["bash", "-lc", command],  # noqa: S607
         input=json.dumps({"tool_name": "bash", "tool_input": {"command": "ls"}}),
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=60,
         env=env,
         check=False,
     )

--- a/tests/unit/test_mcp_gateway_evaluator_settings.py
+++ b/tests/unit/test_mcp_gateway_evaluator_settings.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from mcp_gateway.config import EvaluatorSettings
+
+
+def test_defaults_match_design(monkeypatch: pytest.MonkeyPatch) -> None:
+    """env が一切設定されていないときの既定値を検証する。"""
+    for key in ["CHRONOS_EVALUATOR_API_KEY", "CHRONOS_EVALUATOR_MODEL"]:
+        monkeypatch.delenv(key, raising=False)
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert settings.api_key is None
+    assert settings.model == "claude-haiku-4-5-20251001"
+
+
+def test_env_vars_override_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "sk-test-123")
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MODEL", "openai/gpt-4o-mini")
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert isinstance(settings.api_key, SecretStr)
+    assert settings.api_key.get_secret_value() == "sk-test-123"
+    assert settings.model == "openai/gpt-4o-mini"
+
+
+def test_api_key_is_secret_str(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SecretStr が repr で値を漏らさないことを保証する。"""
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "should-not-leak")
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert "should-not-leak" not in repr(settings)
+    assert "should-not-leak" not in str(settings)
+
+
+def test_extra_env_vars_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """数値系の CHRONOS_EVALUATOR_* env は本クラスでは読まず、ignore される。"""
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "9999")
+    monkeypatch.setenv("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", "99.9")
+
+    settings = EvaluatorSettings(_env_file=None)  # type: ignore[call-arg]
+
+    assert not hasattr(settings, "max_tokens")
+    assert not hasattr(settings, "timeout_seconds")

--- a/tests/unit/test_mcp_gateway_llm_evaluator.py
+++ b/tests/unit/test_mcp_gateway_llm_evaluator.py
@@ -221,23 +221,31 @@ def test_build_user_prompt_handles_empty_memories() -> None:
     assert "</memory>" in out
 
 
+@pytest.fixture
+def mock_litellm(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    mock_acompletion = AsyncMock()
+    monkeypatch.setattr(
+        llm_evaluator_module,
+        "litellm",
+        SimpleNamespace(acompletion=mock_acompletion),
+    )
+    return mock_acompletion
+
+
 @pytest.mark.asyncio
-async def test_judge_returns_allow_on_valid_response() -> None:
+async def test_judge_returns_allow_on_valid_response(mock_litellm: AsyncMock) -> None:
     evaluator = LlmEvaluator(api_key="x", model="claude-haiku-4-5-20251001")
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(return_value=_ok_response('{"decision":"allow"}')),
-    ) as mock_call:
-        out = await evaluator.judge(
-            input_=ToolCallInput(tool_name="bash", tool_input={"command": "ls"}),
-            rules="-",
-            memories=[],
-        )
+    mock_litellm.return_value = _ok_response('{"decision":"allow"}')
+    out = await evaluator.judge(
+        input_=ToolCallInput(tool_name="bash", tool_input={"command": "ls"}),
+        rules="-",
+        memories=[],
+    )
 
     assert out == Decision(decision="allow")
     # 呼び出し引数を最低限検証する
-    assert mock_call.await_count == 1
-    kwargs = mock_call.await_args.kwargs
+    assert mock_litellm.await_count == 1
+    kwargs = mock_litellm.await_args.kwargs
     assert kwargs["model"] == "claude-haiku-4-5-20251001"
     assert kwargs["api_key"] == "x"
     assert kwargs["max_tokens"] == 1536
@@ -246,98 +254,80 @@ async def test_judge_returns_allow_on_valid_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_llm_unavailable_on_timeout() -> None:
+async def test_judge_raises_llm_unavailable_on_timeout(mock_litellm: AsyncMock) -> None:
     evaluator = LlmEvaluator(api_key="x")
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(side_effect=asyncio.TimeoutError()),
-    ):
-        with pytest.raises(LlmUnavailableError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.side_effect = asyncio.TimeoutError()
+    with pytest.raises(LlmUnavailableError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_llm_unavailable_on_api_error() -> None:
+async def test_judge_raises_llm_unavailable_on_api_error(mock_litellm: AsyncMock) -> None:
     evaluator = LlmEvaluator(api_key="x")
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(side_effect=Exception("AuthenticationError")),
-    ):
-        with pytest.raises(LlmUnavailableError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.side_effect = Exception("AuthenticationError")
+    with pytest.raises(LlmUnavailableError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_parse_error_on_empty_content() -> None:
+async def test_judge_raises_parse_error_on_empty_content(mock_litellm: AsyncMock) -> None:
     evaluator = LlmEvaluator(api_key="x")
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(return_value=_ok_response("")),
-    ):
-        with pytest.raises(ResponseParseError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.return_value = _ok_response("")
+    with pytest.raises(ResponseParseError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_parse_error_on_none_content() -> None:
+async def test_judge_raises_parse_error_on_none_content(mock_litellm: AsyncMock) -> None:
     evaluator = LlmEvaluator(api_key="x")
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(return_value=_ok_response(None)),  # type: ignore[arg-type]
-    ):
-        with pytest.raises(ResponseParseError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.return_value = _ok_response(None)  # type: ignore[arg-type]
+    with pytest.raises(ResponseParseError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_parse_error_on_empty_choices() -> None:
+async def test_judge_raises_parse_error_on_empty_choices(mock_litellm: AsyncMock) -> None:
     """choices=[] でも IndexError ではなく ResponseParseError として扱う。"""
     evaluator = LlmEvaluator(api_key="x")
     empty_choices_response = SimpleNamespace(choices=[])
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(return_value=empty_choices_response),
-    ):
-        with pytest.raises(ResponseParseError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.return_value = empty_choices_response
+    with pytest.raises(ResponseParseError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_parse_error_on_missing_message() -> None:
+async def test_judge_raises_parse_error_on_missing_message(mock_litellm: AsyncMock) -> None:
     """choices[0] に message 属性が無くても AttributeError ではなく ResponseParseError。"""
     evaluator = LlmEvaluator(api_key="x")
     # message 属性のない choice (SimpleNamespace は属性アクセス時に AttributeError)
     malformed_response = SimpleNamespace(choices=[SimpleNamespace()])
-    with patch(
-        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
-        new=AsyncMock(return_value=malformed_response),
-    ):
-        with pytest.raises(ResponseParseError):
-            _ = await evaluator.judge(
-                input_=ToolCallInput(tool_name="bash", tool_input={}),
-                rules="",
-                memories=[],
-            )
+    mock_litellm.return_value = malformed_response
+    with pytest.raises(ResponseParseError):
+        _ = await evaluator.judge(
+            input_=ToolCallInput(tool_name="bash", tool_input={}),
+            rules="",
+            memories=[],
+        )
 
 
 def test_system_prompt_contains_role_and_output_format() -> None:

--- a/tests/unit/test_mcp_gateway_llm_evaluator.py
+++ b/tests/unit/test_mcp_gateway_llm_evaluator.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import mcp_gateway.policy.llm_evaluator as llm_evaluator_module
 from mcp_gateway.policy.llm_evaluator import (
     SYSTEM_PROMPT,
     LlmEvaluator,
+    LlmUnavailableError,
     ResponseParseError,
     _build_user_prompt,
     _parse_decision,
@@ -15,17 +18,8 @@ from mcp_gateway.policy.llm_evaluator import (
 from mcp_gateway.policy.models_evaluator import Decision, MemoryItem, ToolCallInput
 
 
-class _FakeMessages:
-    def __init__(self, response: SimpleNamespace) -> None:
-        self._response: SimpleNamespace = response
-
-    def create(self, **_kwargs: object) -> SimpleNamespace:
-        return self._response
-
-
-class _FakeClient:
-    def __init__(self, response: SimpleNamespace) -> None:
-        self.messages: _FakeMessages = _FakeMessages(response)
+def _ok_response(json_text: str) -> SimpleNamespace:
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=json_text))])
 
 
 @pytest.mark.parametrize(
@@ -73,10 +67,10 @@ def test_parse_truncates_long_ask_message() -> None:
         '{"decision":"maybe"}',
         '{"decision":"deny"}',
         '{"decision":"deny","reason":"   "}',
-        '{"decision":"deny","reason":"' + (" " * 201) + 'x"}',  # empty after truncation
+        '{"decision":"deny","reason":"' + (" " * 201) + 'x"}',
         '{"decision":"ask"}',
         '{"decision":"ask","ask_message":"   "}',
-        '{"decision":"ask","ask_message":"' + (" " * 301) + 'y"}',  # empty after truncation
+        '{"decision":"ask","ask_message":"' + (" " * 301) + 'y"}',
     ],
 )
 def test_parse_rejects_invalid(text: str) -> None:
@@ -91,29 +85,22 @@ def test_parse_error_does_not_include_raw_model_output() -> None:
 
 
 def test_from_env_returns_none_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # monkeypatch.setenv で空文字列を入れて os.environ を最優先化する。
+    # `delenv` だけだと Pydantic が EvaluatorSettings の env_file=".env" から
+    # ローカル .env の値を拾い、テストが flaky になる。空 SecretStr は falsy。
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "")
     assert LlmEvaluator.from_env() is None
 
 
-def test_from_env_returns_none_when_anthropic_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
-    with patch("importlib.import_module", side_effect=ImportError("not installed")):
+def test_from_env_returns_none_when_litellm_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "test-key")
+    monkeypatch.setattr(llm_evaluator_module, "litellm", None)
+    with patch("mcp_gateway.policy.llm_evaluator.importlib.import_module", side_effect=ImportError):
         assert LlmEvaluator.from_env() is None
 
 
-def test_from_env_bumps_max_tokens_if_budget_too_high(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
-    monkeypatch.setenv("CHRONOS_EVALUATOR_THINKING_BUDGET", "2000")
-    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "1500")
-
-    evaluator = LlmEvaluator.from_env()
-    assert evaluator is not None
-    assert evaluator._thinking_budget == 2000
-    assert evaluator._max_tokens > 2000
-
-
 def test_from_env_respects_max_tokens_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "test-key")
     monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "4096")
     evaluator = LlmEvaluator.from_env()
     assert evaluator is not None
@@ -121,25 +108,52 @@ def test_from_env_respects_max_tokens_env(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 def test_from_env_handles_invalid_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    """timeout の不正値/非正値は **fail-soft** で警告 + デフォルト 10.0 に正規化される。
 
-    # Case 1: Invalid float string
+    現行実装の挙動を維持する。fail-fast (ValidationError) には移行しない。
+    """
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "test-key")
+
+    # Case 1: 数値変換不可文字列
     monkeypatch.setenv("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", "invalid")
     evaluator = LlmEvaluator.from_env()
     assert evaluator is not None
     assert evaluator._timeout_seconds == 10.0
 
-    # Case 2: Non-positive float
+    # Case 2: 非正値
     monkeypatch.setenv("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", "0.0")
     evaluator = LlmEvaluator.from_env()
     assert evaluator is not None
     assert evaluator._timeout_seconds == 10.0
 
-    # Case 3: Valid positive float
+    # Case 3: 正値はそのまま採用
     monkeypatch.setenv("CHRONOS_EVALUATOR_TIMEOUT_SECONDS", "5.5")
     evaluator = LlmEvaluator.from_env()
     assert evaluator is not None
     assert evaluator._timeout_seconds == 5.5
+
+
+def test_from_env_handles_invalid_max_tokens_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """max_tokens の不正値/非正値は **fail-soft** で警告 + デフォルト 1536 に正規化される。"""
+    monkeypatch.setenv("CHRONOS_EVALUATOR_API_KEY", "test-key")
+
+    # Case 1: 数値変換不可文字列
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "invalid")
+    evaluator = LlmEvaluator.from_env()
+    assert evaluator is not None
+    assert evaluator._max_tokens == 1536
+
+    # Case 2: 非正値 (0)
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "0")
+    evaluator = LlmEvaluator.from_env()
+    assert evaluator is not None
+    assert evaluator._max_tokens == 1536
+
+    # Case 3: 正値はそのまま採用
+    monkeypatch.setenv("CHRONOS_EVALUATOR_MAX_TOKENS", "2048")
+    evaluator = LlmEvaluator.from_env()
+    assert evaluator is not None
+    assert evaluator._max_tokens == 2048
 
 
 def test_build_user_prompt_redacts_sensitive_keys() -> None:
@@ -210,12 +224,10 @@ def test_build_user_prompt_handles_empty_memories() -> None:
 @pytest.mark.asyncio
 async def test_judge_returns_allow_on_valid_response() -> None:
     evaluator = LlmEvaluator(api_key="x", model="claude-haiku-4-5-20251001")
-    fake_response = SimpleNamespace(
-        content=[SimpleNamespace(type="text", text='{"decision":"allow"}')]
-    )
-    fake_client = _FakeClient(fake_response)
-
-    with patch.object(evaluator, "_get_client", return_value=fake_client):
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(return_value=_ok_response('{"decision":"allow"}')),
+    ) as mock_call:
         out = await evaluator.judge(
             input_=ToolCallInput(tool_name="bash", tool_input={"command": "ls"}),
             rules="-",
@@ -223,15 +235,103 @@ async def test_judge_returns_allow_on_valid_response() -> None:
         )
 
     assert out == Decision(decision="allow")
+    # 呼び出し引数を最低限検証する
+    assert mock_call.await_count == 1
+    kwargs = mock_call.await_args.kwargs
+    assert kwargs["model"] == "claude-haiku-4-5-20251001"
+    assert kwargs["api_key"] == "x"
+    assert kwargs["max_tokens"] == 1536
+    assert kwargs["timeout"] == 10.0
+    assert kwargs["messages"][0] == {"role": "system", "content": SYSTEM_PROMPT}
 
 
 @pytest.mark.asyncio
-async def test_judge_raises_on_non_text_response() -> None:
+async def test_judge_raises_llm_unavailable_on_timeout() -> None:
     evaluator = LlmEvaluator(api_key="x")
-    fake_response = SimpleNamespace(content=[])
-    fake_client = _FakeClient(fake_response)
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(side_effect=asyncio.TimeoutError()),
+    ):
+        with pytest.raises(LlmUnavailableError):
+            _ = await evaluator.judge(
+                input_=ToolCallInput(tool_name="bash", tool_input={}),
+                rules="",
+                memories=[],
+            )
 
-    with patch.object(evaluator, "_get_client", return_value=fake_client):
+
+@pytest.mark.asyncio
+async def test_judge_raises_llm_unavailable_on_api_error() -> None:
+    evaluator = LlmEvaluator(api_key="x")
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(side_effect=Exception("AuthenticationError")),
+    ):
+        with pytest.raises(LlmUnavailableError):
+            _ = await evaluator.judge(
+                input_=ToolCallInput(tool_name="bash", tool_input={}),
+                rules="",
+                memories=[],
+            )
+
+
+@pytest.mark.asyncio
+async def test_judge_raises_parse_error_on_empty_content() -> None:
+    evaluator = LlmEvaluator(api_key="x")
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(return_value=_ok_response("")),
+    ):
+        with pytest.raises(ResponseParseError):
+            _ = await evaluator.judge(
+                input_=ToolCallInput(tool_name="bash", tool_input={}),
+                rules="",
+                memories=[],
+            )
+
+
+@pytest.mark.asyncio
+async def test_judge_raises_parse_error_on_none_content() -> None:
+    evaluator = LlmEvaluator(api_key="x")
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(return_value=_ok_response(None)),  # type: ignore[arg-type]
+    ):
+        with pytest.raises(ResponseParseError):
+            _ = await evaluator.judge(
+                input_=ToolCallInput(tool_name="bash", tool_input={}),
+                rules="",
+                memories=[],
+            )
+
+
+@pytest.mark.asyncio
+async def test_judge_raises_parse_error_on_empty_choices() -> None:
+    """choices=[] でも IndexError ではなく ResponseParseError として扱う。"""
+    evaluator = LlmEvaluator(api_key="x")
+    empty_choices_response = SimpleNamespace(choices=[])
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(return_value=empty_choices_response),
+    ):
+        with pytest.raises(ResponseParseError):
+            _ = await evaluator.judge(
+                input_=ToolCallInput(tool_name="bash", tool_input={}),
+                rules="",
+                memories=[],
+            )
+
+
+@pytest.mark.asyncio
+async def test_judge_raises_parse_error_on_missing_message() -> None:
+    """choices[0] に message 属性が無くても AttributeError ではなく ResponseParseError。"""
+    evaluator = LlmEvaluator(api_key="x")
+    # message 属性のない choice (SimpleNamespace は属性アクセス時に AttributeError)
+    malformed_response = SimpleNamespace(choices=[SimpleNamespace()])
+    with patch(
+        "mcp_gateway.policy.llm_evaluator.litellm.acompletion",
+        new=AsyncMock(return_value=malformed_response),
+    ):
         with pytest.raises(ResponseParseError):
             _ = await evaluator.judge(
                 input_=ToolCallInput(tool_name="bash", tool_input={}),
@@ -245,15 +345,3 @@ def test_system_prompt_contains_role_and_output_format() -> None:
     assert "<output_format>" in SYSTEM_PROMPT
     assert "untrusted data" in SYSTEM_PROMPT
     assert "allow" in SYSTEM_PROMPT and "deny" in SYSTEM_PROMPT and "ask" in SYSTEM_PROMPT
-
-
-def test_llm_evaluator_init_raises_on_invalid_thinking_budget() -> None:
-    with pytest.raises(
-        ValueError, match=r"thinking_budget \(2000\) must be less than max_tokens \(1000\)"
-    ):
-        LlmEvaluator(api_key="x", thinking_budget=2000, max_tokens=1000)
-
-    with pytest.raises(
-        ValueError, match=r"thinking_budget \(1000\) must be less than max_tokens \(1000\)"
-    ):
-        LlmEvaluator(api_key="x", thinking_budget=1000, max_tokens=1000)

--- a/uv.lock
+++ b/uv.lock
@@ -141,25 +141,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.100.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596 },
-]
-
-[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -422,7 +403,6 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "anthropic" },
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "litellm" },
@@ -451,7 +431,7 @@ embedding-openai = [
     { name = "openai" },
 ]
 evaluator = [
-    { name = "anthropic" },
+    { name = "litellm" },
 ]
 storage-postgres = [
     { name = "asyncpg" },
@@ -476,13 +456,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
-    { name = "anthropic", marker = "extra == 'evaluator'", specifier = ">=0.40.0" },
     { name = "asyncpg", marker = "extra == 'storage-postgres'", specifier = ">=0.29.0" },
     { name = "context-store-mcp", extras = ["storage-postgres", "storage-supabase", "embedding-local", "embedding-openai", "embedding-litellm", "dashboard", "evaluator"], marker = "extra == 'all'" },
     { name = "fastapi", marker = "extra == 'dashboard'", specifier = ">=0.115.0" },
     { name = "filelock", specifier = ">=3.13.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", marker = "extra == 'embedding-litellm'", specifier = ">=1.0.0" },
+    { name = "litellm", marker = "extra == 'evaluator'", specifier = ">=1.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "neo4j", marker = "extra == 'storage-postgres'", specifier = ">=5.0.0" },
     { name = "numpy", marker = "extra == 'embedding-local'", specifier = ">=1.26.0" },
@@ -738,15 +718,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `LlmEvaluator` を Anthropic SDK 直結から `litellm.acompletion` 経由に書き換え
- `pyproject.toml` の `evaluator` extra を `anthropic>=0.40.0` → `litellm>=1.0.0` へ差替
- 環境変数 `ANTHROPIC_API_KEY` を `CHRONOS_EVALUATOR_API_KEY` に移行
- `thinking_budget`, `_get_client`, threading lock, Protocol 群, `cache_control:ephemeral` を削除
- 数値設定 (`max_tokens`, `timeout_seconds`) の **fail-soft 挙動を維持** (`_parse_int_env` / `_parse_float_env` をモジュールレベルに昇格して再利用)
- `judge()` の OpenAI 互換レスポンス解析を try ブロックで保護し、`choices=[]` / `message` 欠落で `IndexError`/`AttributeError` が漏れないよう `ResponseParseError` に変換
- ユニットテストを LiteLLM 用に書き直し、エラーパス 6 ケース (`timeout`, `api_error`, `empty_content`, `none_content`, `empty_choices`, `missing_message`) を追加
- `from_env` テストの `.env` 依存を解消 (`monkeypatch.setenv("...", "")`)
- 統合テスト (`test_evaluator_cli_subprocess.py`) の env var 名を更新

## Stack
- Depends on: feat/evaluator-settings (Task 1.1 Draft PR)

## Test plan
- [x] `pytest tests/unit/test_mcp_gateway_llm_evaluator.py` 全件 PASS (33 tests)
- [x] `pytest tests/unit/test_mcp_gateway_evaluator_settings.py` 全件 PASS (4 tests)
- [x] `pytest tests/integration/test_evaluator_cli_subprocess.py` 全件 PASS (4 tests)
- [x] `ruff check` / `ruff format --check` / `mypy` エラー 0
- [x] `git grep "anthropic"` がコードと pyproject.toml で 0 件

Refs: docs/superpowers/specs/2026-05-25-litellm-evaluator-refactor-design.md