### PR TITLE
fix(ci): switch runner back to ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,16 @@ name: CI
 
 on:
   push:
-    branches: ["master", "**"]
+    branches: ["master"]
+  # NOTE: pull_request には branches フィルタを設定しない。
+  # 本リポジトリは stacked PR ワークフローを採用しており、Task 2.1 / 3.1 のような
+  # base=feature-branch の PR でも CI を必ず起動させるため、target branch を絞らない。
+  # push は master のみに限定して masters を二重実行しない。
   pull_request:
-    branches: ["master", "main"]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,6 +37,6 @@ jobs:
         run: uv run mypy src/
 
       - name: Run unit tests
-        run: uv run pytest tests/unit -v --cov=src/context_store --cov-report=term-missing
+        run: uv run pytest tests/unit -v --cov=src/context_store --cov=src/mcp_gateway --cov-report=term-missing
         env:
           OPENAI_API_KEY: sk-dummy-key-for-ci-validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary
Code review で `ubuntu-slim` (1 CPU / 5 GB RAM) は多数の extras をインストールする本ワークフローには非推奨との指摘を受けました。`ubuntu-latest` (4 CPU / 16 GB RAM) に戻します。

Refs: #260