### PR TITLE
perf(storage): reduce Supabase memory timeout overhead

### DIFF
--- a/docs/superpowers/plans/2026-05-26-mcp-memory-timeout-reduction-phase1.md
+++ b/docs/superpowers/plans/2026-05-26-mcp-memory-timeout-reduction-phase1.md
@@ -62,7 +62,7 @@
 - Modify: `tests/unit/storage/test_config_supabase.py`
 - Modify: `tests/unit/storage/test_supabase_adapter.py`
 
-- [ ] **Step 1: Add a failing test for the new setting default**
+- [x] **Step 1: Add a failing test for the new setting default**
 
 Append to `tests/unit/storage/test_config_supabase.py`:
 
@@ -96,12 +96,12 @@ def test_supabase_request_timeout_env_override(monkeypatch):
     assert settings.supabase_request_timeout_seconds == 30.0
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 Run: `uv run pytest tests/unit/storage/test_config_supabase.py::test_supabase_request_timeout_default tests/unit/storage/test_config_supabase.py::test_supabase_request_timeout_env_override -v`
 Expected: FAIL with `AttributeError` on `supabase_request_timeout_seconds`.
 
-- [ ] **Step 3: Add the setting**
+- [x] **Step 3: Add the setting**
 
 In `src/context_store/config.py`, add inside `class Settings` (right after the existing `supabase_key` field around line 99-103):
 
@@ -114,12 +114,12 @@ In `src/context_store/config.py`, add inside `class Settings` (right after the e
     )
 ```
 
-- [ ] **Step 4: Re-run the setting tests**
+- [x] **Step 4: Re-run the setting tests**
 
 Run: `uv run pytest tests/unit/storage/test_config_supabase.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Add a failing test that the adapter passes options through**
+- [x] **Step 5: Add a failing test that the adapter passes options through**
 
 Append to `tests/unit/storage/test_supabase_adapter.py`:
 
@@ -163,12 +163,12 @@ async def test_create_passes_request_timeout_to_client(monkeypatch):
     assert captured["options"].postgrest_client_timeout == 12.5
 ```
 
-- [ ] **Step 6: Run the adapter test and confirm it fails**
+- [x] **Step 6: Run the adapter test and confirm it fails**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py::test_create_passes_request_timeout_to_client -v`
 Expected: FAIL — `captured["options"]` is `None` because the adapter does not pass options.
 
-- [ ] **Step 7: Update the adapter to construct and pass `AsyncClientOptions`**
+- [x] **Step 7: Update the adapter to construct and pass `AsyncClientOptions`**
 
 In `src/context_store/storage/supabase.py`, change the `try` block at the top to import `AsyncClientOptions`:
 
@@ -204,17 +204,17 @@ Then in `SupabaseStorageAdapter.create` (lines 69-95), change the `create_async_
         )
 ```
 
-- [ ] **Step 8: Re-run the adapter test**
+- [x] **Step 8: Re-run the adapter test**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py::test_create_passes_request_timeout_to_client -v`
 Expected: PASS.
 
-- [ ] **Step 9: Run the full Supabase adapter test module to catch regressions**
+- [x] **Step 9: Run the full Supabase adapter test module to catch regressions**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py -v`
 Expected: All PASS (existing tests continue to work because the new option is additive).
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 git add src/context_store/config.py src/context_store/storage/supabase.py \
@@ -230,7 +230,7 @@ git commit -m "feat(storage): add supabase_request_timeout_seconds and wire thro
 - Modify: `src/context_store/storage/supabase.py`
 - Modify: `tests/unit/storage/test_supabase_adapter.py`
 
-- [ ] **Step 1: Add a failing test that asserts the second call does not hit the wire**
+- [x] **Step 1: Add a failing test that asserts the second call does not hit the wire**
 
 Append to `tests/unit/storage/test_supabase_adapter.py`:
 
@@ -256,12 +256,12 @@ async def test_get_vector_dimension_is_cached_after_first_call():
     client.rpc.assert_not_called()
 ```
 
-- [ ] **Step 2: Run the test and confirm it fails**
+- [x] **Step 2: Run the test and confirm it fails**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py::test_get_vector_dimension_is_cached_after_first_call -v`
 Expected: FAIL — `chain.execute` is called a second time.
 
-- [ ] **Step 3: Add a `_cached_dimension` field and short-circuit logic**
+- [x] **Step 3: Add a `_cached_dimension` field and short-circuit logic**
 
 In `src/context_store/storage/supabase.py`, update `__init__` (around line 66) and `get_vector_dimension` (line 97):
 
@@ -310,17 +310,17 @@ In `src/context_store/storage/supabase.py`, update `__init__` (around line 66) a
         )
 ```
 
-- [ ] **Step 4: Re-run the test**
+- [x] **Step 4: Re-run the test**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py::test_get_vector_dimension_is_cached_after_first_call -v`
 Expected: PASS.
 
-- [ ] **Step 5: Run the full Supabase adapter and orchestrator tests to verify no regressions**
+- [x] **Step 5: Run the full Supabase adapter and orchestrator tests to verify no regressions**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py tests/unit/test_orchestrator.py -v`
 Expected: All PASS. (The existing `Orchestrator._check_vector_dimension` continues to call `get_vector_dimension`, but the cached value short-circuits the second round trip.)
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/context_store/storage/supabase.py tests/unit/storage/test_supabase_adapter.py
@@ -336,7 +336,7 @@ git commit -m "perf(storage): cache Supabase vector dimension to avoid duplicate
 - Modify: `src/context_store/storage/supabase.py`
 - Modify: `tests/unit/storage/test_supabase_adapter.py`
 
-- [ ] **Step 1: Create the new migration**
+- [x] **Step 1: Create the new migration**
 
 Create `supabase/migrations/20260526000001_vector_search_brief.sql` with:
 
@@ -393,7 +393,7 @@ $$;
 GRANT EXECUTE ON FUNCTION vector_search_brief(vector, integer, text) TO service_role;
 ```
 
-- [ ] **Step 2: Add a failing test for the new RPC name**
+- [x] **Step 2: Add a failing test for the new RPC name**
 
 Append to `tests/unit/storage/test_supabase_adapter.py`:
 
@@ -437,12 +437,12 @@ async def test_vector_search_uses_brief_rpc_and_returns_empty_embedding():
     assert call_args[0][0] == "vector_search_brief"
 ```
 
-- [ ] **Step 3: Run the test and confirm it fails**
+- [x] **Step 3: Run the test and confirm it fails**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py::test_vector_search_uses_brief_rpc_and_returns_empty_embedding -v`
 Expected: FAIL — adapter still calls `vector_search`.
 
-- [ ] **Step 4: Update the adapter to call the brief RPC**
+- [x] **Step 4: Update the adapter to call the brief RPC**
 
 In `src/context_store/storage/supabase.py`, change `vector_search` (line 280):
 
@@ -453,7 +453,7 @@ In `src/context_store/storage/supabase.py`, change `vector_search` (line 280):
             raise self._map_to_storage_error(exc) from exc
 ```
 
-- [ ] **Step 5: Update the existing `test_vector_search_calls_rpc` test**
+- [x] **Step 5: Update the existing `test_vector_search_calls_rpc` test**
 
 In `tests/unit/storage/test_supabase_adapter.py`, find `test_vector_search_calls_rpc` (around line 472). Update the row builder to drop the `"embedding"` key (the brief RPC does not return it) and change the assertion:
 
@@ -465,12 +465,12 @@ In `tests/unit/storage/test_supabase_adapter.py`, find `test_vector_search_calls
 
 Also update the row dict in that test to remove `"embedding": embedding,` and assert `results[0].memory.embedding == []`.
 
-- [ ] **Step 6: Re-run the adapter tests**
+- [x] **Step 6: Re-run the adapter tests**
 
 Run: `uv run pytest tests/unit/storage/test_supabase_adapter.py -v`
 Expected: All PASS.
 
-- [ ] **Step 6.5: Add a SQL-level regression test for the new migration**
+- [x] **Step 6.5: Add a SQL-level regression test for the new migration**
 
 The existing `tests/unit/storage/test_supabase_migrations.py` pins the structure of migrations via `re.search` (see e.g. `test_vector_search_rpc_returns_embedding_column` which fixes the existing `vector_search` schema). Add a sibling test so the new RPC's brief contract cannot regress silently.
 
@@ -505,7 +505,7 @@ def test_vector_search_brief_rpc_omits_embedding_column() -> None:
 Run: `uv run pytest tests/unit/storage/test_supabase_migrations.py::test_vector_search_brief_rpc_omits_embedding_column -v`
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add supabase/migrations/20260526000001_vector_search_brief.sql \

--- a/docs/superpowers/plans/2026-05-26-mcp-memory-timeout-reduction-phase1.md
+++ b/docs/superpowers/plans/2026-05-26-mcp-memory-timeout-reduction-phase1.md
@@ -1698,7 +1698,10 @@ git commit -m "perf(ingestion): batch-embed all chunks in a single provider call
 
 ---
 
-## Final Verification
+## Final Verification (Perform after completing Tasks 1–7)
+
+> [!IMPORTANT]
+> Perform this Final Verification only after completing all Tasks 1–7 (including the second migration in Task 5). This is the final check following the second migration, rather than a step-by-step verification after Tasks 1–3. Specifically, Step 4 below requires the migrations from Task 5 to be fully applied.
 
 **Execution environment:** Per `AGENTS.md` / `CLAUDE.md` §5, all backend verification commands below **MUST be run inside the project devcontainer** (`.devcontainer/`). Running them on the host risks toolchain drift (e.g. different `uv`, mismatched `ruff`/`mypy` versions, missing `aiosqlite` wheels for the host arch) and is not a supported configuration. Open the workspace in the devcontainer (`Reopen in Container` in VS Code, or `devcontainer up && devcontainer exec`) before proceeding.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ storage-postgres = [
     "redis>=5.0.0",
 ]
 storage-supabase = [
-    "supabase>=2.4.0",
+    "supabase>=2.30.0",
 ]
 embedding-local = [
     "sentence-transformers>=3.0.0",

--- a/src/context_store/config.py
+++ b/src/context_store/config.py
@@ -100,6 +100,12 @@ class Settings(BaseSettings):
         default=SecretStr(""),
         description="Service Role Key または Anon Key",
     )
+    # --- Supabase request timeout (postgrest_client_timeout) ---
+    supabase_request_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0.0,
+        description="Per-request timeout (seconds) for Supabase Data API calls.",
+    )
 
     # --- Neo4j (graph_enabled=true の場合) ---
     neo4j_uri: str = "bolt://localhost:7687"

--- a/src/context_store/storage/supabase.py
+++ b/src/context_store/storage/supabase.py
@@ -116,8 +116,12 @@ class SupabaseStorageAdapter:
                 .not_.is_("embedding", "null")
                 .limit(1)
             )
-            response = await chain.execute()
-            rows = response.data or []
+            try:
+                response = await chain.execute()
+                rows = response.data or []
+            except Exception as exc:
+                raise self._map_to_storage_error(exc) from exc
+
             if rows:
                 embedding = _parse_embedding(rows[0].get("embedding"))
                 if embedding:

--- a/src/context_store/storage/supabase.py
+++ b/src/context_store/storage/supabase.py
@@ -17,12 +17,14 @@ try:  # noqa: I001
 
     from supabase import (  # type: ignore[attr-defined]  # noqa: F401
         AsyncClient,
+        AsyncClientOptions,
         create_async_client,
     )
 
     _supabase_available = True
 except ImportError:
     AsyncClient = Any  # type: ignore[misc,assignment]
+    AsyncClientOptions = Any  # type: ignore[misc,assignment]
     PostgrestAPIError = Exception  # type: ignore[misc,assignment]
     _supabase_available = False
 
@@ -65,6 +67,7 @@ class SupabaseStorageAdapter:
 
     def __init__(self, client: "AsyncClient") -> None:
         self._client = client
+        self._cached_dimension: int | None = None
 
     @classmethod
     async def create(cls, settings: "Settings") -> "SupabaseStorageAdapter":
@@ -75,6 +78,9 @@ class SupabaseStorageAdapter:
         client = await create_async_client(
             settings.supabase_url,
             settings.supabase_key.get_secret_value(),
+            options=AsyncClientOptions(
+                postgrest_client_timeout=settings.supabase_request_timeout_seconds,
+            ),
         )
         adapter = cls(client)
         try:
@@ -95,6 +101,9 @@ class SupabaseStorageAdapter:
         return adapter
 
     async def get_vector_dimension(self) -> int | None:
+        if self._cached_dimension is not None:
+            return self._cached_dimension
+
         chain = (
             self._client.table("memories")
             .select("embedding")
@@ -106,7 +115,8 @@ class SupabaseStorageAdapter:
         if rows:
             embedding = _parse_embedding(rows[0].get("embedding"))
             if embedding:
-                return len(embedding)
+                self._cached_dimension = len(embedding)
+                return self._cached_dimension
         # Empty table: query schema dimension via RPC
         try:
             rpc_response = await self._client.rpc("get_embedding_dimension", {}).execute()
@@ -120,7 +130,8 @@ class SupabaseStorageAdapter:
         else:
             dim = None
         if isinstance(dim, int) and dim > 0:
-            return dim
+            self._cached_dimension = dim
+            return self._cached_dimension
         raise StorageError(
             "Could not determine memories.embedding dimension from schema. "
             "Ensure pgvector extension is installed and the memories table exists.",
@@ -277,7 +288,7 @@ class SupabaseStorageAdapter:
             "p_project": project,
         }
         try:
-            response = await self._client.rpc("vector_search", params).execute()
+            response = await self._client.rpc("vector_search_brief", params).execute()
         except Exception as exc:
             raise self._map_to_storage_error(exc) from exc
 

--- a/src/context_store/storage/supabase.py
+++ b/src/context_store/storage/supabase.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -68,6 +69,7 @@ class SupabaseStorageAdapter:
     def __init__(self, client: "AsyncClient") -> None:
         self._client = client
         self._cached_dimension: int | None = None
+        self._dimension_lock = asyncio.Lock()
 
     @classmethod
     async def create(cls, settings: "Settings") -> "SupabaseStorageAdapter":
@@ -104,40 +106,44 @@ class SupabaseStorageAdapter:
         if self._cached_dimension is not None:
             return self._cached_dimension
 
-        chain = (
-            self._client.table("memories")
-            .select("embedding")
-            .not_.is_("embedding", "null")
-            .limit(1)
-        )
-        response = await chain.execute()
-        rows = response.data or []
-        if rows:
-            embedding = _parse_embedding(rows[0].get("embedding"))
-            if embedding:
-                self._cached_dimension = len(embedding)
+        async with self._dimension_lock:
+            if self._cached_dimension is not None:
                 return self._cached_dimension
-        # Empty table: query schema dimension via RPC
-        try:
-            rpc_response = await self._client.rpc("get_embedding_dimension", {}).execute()
-        except Exception as exc:
-            raise self._map_to_storage_error(exc) from exc
-        data = rpc_response.data
-        if isinstance(data, list) and data:
-            dim = data[0]
-        elif isinstance(data, int):
-            dim = data
-        else:
-            dim = None
-        if isinstance(dim, int) and dim > 0:
-            self._cached_dimension = dim
-            return self._cached_dimension
-        raise StorageError(
-            "Could not determine memories.embedding dimension from schema. "
-            "Ensure pgvector extension is installed and the memories table exists.",
-            code="INVALID_STATE",
-            recoverable=False,
-        )
+
+            chain = (
+                self._client.table("memories")
+                .select("embedding")
+                .not_.is_("embedding", "null")
+                .limit(1)
+            )
+            response = await chain.execute()
+            rows = response.data or []
+            if rows:
+                embedding = _parse_embedding(rows[0].get("embedding"))
+                if embedding:
+                    self._cached_dimension = len(embedding)
+                    return self._cached_dimension
+            # Empty table: query schema dimension via RPC
+            try:
+                rpc_response = await self._client.rpc("get_embedding_dimension", {}).execute()
+            except Exception as exc:
+                raise self._map_to_storage_error(exc) from exc
+            data = rpc_response.data
+            if isinstance(data, list) and data:
+                dim = data[0]
+            elif isinstance(data, int):
+                dim = data
+            else:
+                dim = None
+            if isinstance(dim, int) and dim > 0:
+                self._cached_dimension = dim
+                return self._cached_dimension
+            raise StorageError(
+                "Could not determine memories.embedding dimension from schema. "
+                "Ensure pgvector extension is installed and the memories table exists.",
+                code="INVALID_STATE",
+                recoverable=False,
+            )
 
     async def dispose(self) -> None:
         client = self._client

--- a/supabase/migrations/20260526000001_vector_search_brief.sql
+++ b/supabase/migrations/20260526000001_vector_search_brief.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- vector_search_brief: same as vector_search but omits the
+-- embedding column from the return row. Reduces per-row payload
+-- by ~10KB (768 floats × JSON encoding overhead) for clients
+-- that only need the score + memory metadata for display.
+-- The original vector_search is kept for backward compatibility.
+-- ============================================================
+CREATE OR REPLACE FUNCTION vector_search_brief(
+    query_embedding vector(768),
+    match_count     integer,
+    p_project       text DEFAULT NULL
+)
+RETURNS TABLE (
+    id                 uuid,
+    content            text,
+    memory_type        varchar,
+    source_type        varchar,
+    source_metadata    jsonb,
+    semantic_relevance float,
+    importance_score   float,
+    access_count       integer,
+    last_accessed_at   timestamptz,
+    created_at         timestamptz,
+    updated_at         timestamptz,
+    archived_at        timestamptz,
+    tags               text[],
+    project            text,
+    content_hash       text,
+    score              float
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+    SELECT
+        m.id, m.content, m.memory_type, m.source_type, m.source_metadata,
+        m.semantic_relevance, m.importance_score, m.access_count,
+        m.last_accessed_at, m.created_at, m.updated_at, m.archived_at,
+        m.tags, m.project, m.content_hash,
+        (1 - (m.embedding <=> query_embedding))::float AS score
+    FROM memories m
+    WHERE m.archived_at IS NULL
+      AND m.embedding IS NOT NULL
+      AND (p_project IS NULL OR m.project = p_project)
+    ORDER BY m.embedding <=> query_embedding
+    LIMIT COALESCE(GREATEST(match_count, 0), 0);
+$$;
+
+GRANT EXECUTE ON FUNCTION vector_search_brief(vector, integer, text) TO service_role;

--- a/tests/unit/storage/test_config_supabase.py
+++ b/tests/unit/storage/test_config_supabase.py
@@ -55,3 +55,33 @@ def test_default_embedding_dimension_is_768():
 def test_graph_backend_for_supabase_is_disabled():
     s = _make_supabase_settings()
     assert s.graph_backend == "disabled"
+
+
+def test_supabase_request_timeout_default(monkeypatch):
+    """Default request timeout should be 10.0 seconds."""
+    monkeypatch.setenv("STORAGE_BACKEND", "supabase")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "service-role-key")
+    monkeypatch.setenv("EMBEDDING_DIMENSION", "768")
+    monkeypatch.delenv("SUPABASE_REQUEST_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv("ENV_FILE", "/dev/null")
+
+    from context_store.config import get_settings
+
+    settings = get_settings()
+    assert settings.supabase_request_timeout_seconds == 10.0
+
+
+def test_supabase_request_timeout_env_override(monkeypatch):
+    """SUPABASE_REQUEST_TIMEOUT_SECONDS should override the default."""
+    monkeypatch.setenv("STORAGE_BACKEND", "supabase")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "service-role-key")
+    monkeypatch.setenv("EMBEDDING_DIMENSION", "768")
+    monkeypatch.setenv("SUPABASE_REQUEST_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("ENV_FILE", "/dev/null")
+
+    from context_store.config import get_settings
+
+    settings = get_settings()
+    assert settings.supabase_request_timeout_seconds == 30.0

--- a/tests/unit/storage/test_supabase_adapter.py
+++ b/tests/unit/storage/test_supabase_adapter.py
@@ -112,6 +112,25 @@ async def test_get_vector_dimension_queries_schema_when_empty():
 
 
 @pytest.mark.asyncio
+async def test_get_vector_dimension_is_cached_after_first_call():
+    """Subsequent get_vector_dimension calls must not issue another HTTP request."""
+    client = make_mock_client()
+    vec_768 = "[" + ",".join(["0.1"] * 768) + "]"
+    chain = client.table.return_value.select.return_value.not_.is_.return_value.limit.return_value
+    chain.execute = AsyncMock(return_value=make_mock_response(data=[{"embedding": vec_768}]))
+
+    adapter = SupabaseStorageAdapter(client)
+    assert await adapter.get_vector_dimension() == 768
+    # Reset the mock so any further call is observable.
+    chain.execute.reset_mock()
+    client.rpc.reset_mock()
+
+    assert await adapter.get_vector_dimension() == 768
+    chain.execute.assert_not_called()
+    client.rpc.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_create_succeeds_when_table_empty():
     client = make_mock_client()
     chain = client.table.return_value.select.return_value.not_.is_.return_value.limit.return_value
@@ -133,6 +152,45 @@ async def test_create_succeeds_when_table_empty():
     ):
         adapter = await SupabaseStorageAdapter.create(settings)
     assert isinstance(adapter, SupabaseStorageAdapter)
+
+
+@pytest.mark.asyncio
+async def test_create_passes_request_timeout_to_client(monkeypatch):
+    """SupabaseStorageAdapter.create should pass postgrest_client_timeout."""
+    captured = {}
+
+    async def fake_create_async_client(url, key, options=None):
+        captured["url"] = url
+        captured["key"] = key
+        captured["options"] = options
+        client = make_mock_client()
+        # The factory's internal dimension probe must succeed:
+        vec_768 = "[" + ",".join(["0.1"] * 768) + "]"
+        chain = (
+            client.table.return_value.select.return_value.not_.is_.return_value.limit.return_value
+        )
+        chain.execute = AsyncMock(return_value=make_mock_response(data=[{"embedding": vec_768}]))
+        return client
+
+    monkeypatch.setattr(
+        "context_store.storage.supabase.create_async_client",
+        fake_create_async_client,
+    )
+
+    settings = Settings(
+        storage_backend="supabase",
+        supabase_url="https://example.supabase.co",
+        supabase_key="srk",
+        embedding_dimension=768,
+        supabase_request_timeout_seconds=12.5,
+        _env_file=None,
+    )
+
+    adapter = await SupabaseStorageAdapter.create(settings)
+    await adapter.dispose()
+
+    assert captured["options"] is not None
+    assert captured["options"].postgrest_client_timeout == 12.5
 
 
 @pytest.mark.asyncio
@@ -472,7 +530,6 @@ async def test_increment_memory_access_count_invokes_rpc():
 async def test_vector_search_calls_rpc():
     client = make_mock_client()
     now = datetime.now(timezone.utc)
-    embedding = "[0.1,0.2,0.3]"
     rows: list[dict[str, Any]] = [
         {
             "id": "550e8400-e29b-41d4-a716-446655440001",
@@ -480,7 +537,6 @@ async def test_vector_search_calls_rpc():
             "memory_type": "semantic",
             "source_type": "manual",
             "source_metadata": {},
-            "embedding": embedding,
             "semantic_relevance": 0.5,
             "importance_score": 0.5,
             "access_count": 0,
@@ -501,13 +557,52 @@ async def test_vector_search_calls_rpc():
     assert len(results) == 1
     assert isinstance(results[0], ScoredMemory)
     assert results[0].score == 0.95
-    assert results[0].memory.embedding == [0.1, 0.2, 0.3]
+    assert results[0].memory.embedding == []
 
     call_args = client.rpc.call_args
-    assert call_args[0][0] == "vector_search"
+    assert call_args[0][0] == "vector_search_brief"
     assert call_args[0][1]["query_embedding"] == "[" + ",".join("0.1" for _ in range(768)) + "]"
     assert call_args[0][1]["match_count"] == 5
     assert call_args[0][1]["p_project"] == "p1"
+
+
+@pytest.mark.asyncio
+async def test_vector_search_uses_brief_rpc_and_returns_empty_embedding():
+    """vector_search should call vector_search_brief and return empty embeddings."""
+    client = make_mock_client()
+    rpc_chain = client.rpc.return_value
+    rpc_chain.execute = AsyncMock(
+        return_value=make_mock_response(
+            data=[
+                {
+                    "id": "550e8400-e29b-41d4-a716-446655440001",
+                    "content": "alpha",
+                    "memory_type": "episodic",
+                    "source_type": "manual",
+                    "source_metadata": {},
+                    "semantic_relevance": 0.5,
+                    "importance_score": 0.5,
+                    "access_count": 0,
+                    "last_accessed_at": "2026-05-26T00:00:00+00:00",
+                    "created_at": "2026-05-26T00:00:00+00:00",
+                    "updated_at": "2026-05-26T00:00:00+00:00",
+                    "archived_at": None,
+                    "tags": [],
+                    "project": "p1",
+                    "content_hash": "h",
+                    "score": 0.9,
+                }
+            ]
+        )
+    )
+
+    adapter = SupabaseStorageAdapter(client)
+    results = await adapter.vector_search([0.1] * 768, top_k=5, project="p1")
+
+    assert len(results) == 1
+    assert results[0].memory.embedding == []  # brief RPC returns no embedding
+    call_args = client.rpc.call_args
+    assert call_args[0][0] == "vector_search_brief"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/test_supabase_migrations.py
+++ b/tests/unit/storage/test_supabase_migrations.py
@@ -58,3 +58,28 @@ def test_get_embedding_dimension_rpc_grants_service_role() -> None:
         )
         is not None
     )
+
+
+def test_vector_search_brief_rpc_omits_embedding_column() -> None:
+    sql = Path("supabase/migrations/20260526000001_vector_search_brief.sql").read_text()
+
+    assert "CREATE OR REPLACE FUNCTION vector_search_brief(" in sql
+
+    match = re.search(r"RETURNS TABLE\s*\((?P<columns>.*?)\)\s*LANGUAGE", sql, re.S)
+    assert match is not None
+    returns_table = match.group("columns")
+    function_body = sql.split("AS $$", 1)[1].split("$$;", 1)[0]
+
+    # The brief RPC must NOT return the embedding column in its result rows.
+    assert re.search(r"\bembedding\s+vector\b", returns_table) is None
+    # Score must still be derived from cosine distance against the embedding.
+    assert "m.embedding <=>" in function_body
+    # Service role grant must be present.
+    assert (
+        re.search(
+            r"GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+vector_search_brief\(.*\)\s+TO\s+service_role",
+            sql,
+            re.I,
+        )
+        is not None
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'embedding-local'", specifier = ">=3.0.0" },
     { name = "sqlite-vec", specifier = ">=0.1.0" },
     { name = "sse-starlette", specifier = ">=2.1.0" },
-    { name = "supabase", marker = "extra == 'storage-supabase'", specifier = ">=2.4.0" },
+    { name = "supabase", marker = "extra == 'storage-supabase'", specifier = ">=2.30.0" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tiktoken", specifier = ">=0.6.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'dashboard'", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary
- Add configurable Supabase Data API request timeout via SUPABASE_REQUEST_TIMEOUT_SECONDS
- Cache Supabase vector dimension after the first successful probe
- Add vector_search_brief RPC and switch vector search to omit embedding payloads
- Raise storage-supabase dependency lower bound for AsyncClientOptions compatibility
- Mark plan Tasks 1-3 complete

## Verification
- uv run pytest tests/unit/storage/test_config_supabase.py tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py tests/unit/test_orchestrator.py -v
- uv run ruff check src/context_store/config.py src/context_store/storage/supabase.py tests/unit/storage/test_config_supabase.py tests/unit/storage/test_supabase_adapter.py tests/unit/storage/test_supabase_migrations.py
- uv run mypy src/
- push hook: lint, format, and type checks passed

## Notes
- Do not merge before applying the new Supabase migration in the target environment.
