### PR TITLE
fix(gateway): stacktrace のシークレット誤検知を部分マスクに修正

### DIFF
--- a/src/mcp_gateway/audit/logger.py
+++ b/src/mcp_gateway/audit/logger.py
@@ -91,7 +91,7 @@ class AuditLogger:
             return {str(k): self._sanitize_value(v, key_name=str(k)) for k, v in value.items()}
 
         if isinstance(value, (list, tuple)):
-            return [self._sanitize_value(item) for item in value]
+            return [self._sanitize_value(item, key_name=key_name) for item in value]
 
         if isinstance(value, (int, float, bool)) or value is None:
             return value

--- a/src/mcp_gateway/audit/logger.py
+++ b/src/mcp_gateway/audit/logger.py
@@ -80,6 +80,8 @@ class AuditLogger:
                 return "**********"
 
         if isinstance(value, str):
+            if key_name and key_name.lower() in {"stacktrace", "traceback"}:
+                return _SENSITIVE_VALUE_RE.sub("**********", value)
             # 値の内容によるチェック
             if _SENSITIVE_VALUE_RE.search(value):
                 return "**********"

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -504,6 +504,30 @@ class TestAuditLogger:
         assert rec["tags"][0] == "normal"
         assert rec["tags"][1] == "**********"
 
+    def test_list_stacktrace_preserves_context_while_redacting_secrets(self, capsys):
+        from mcp_gateway.audit.logger import AuditLogger
+
+        log = AuditLogger()
+        log.log(
+            ev="startup_failure",
+            level="ERROR",
+            stacktrace=[
+                "Traceback (most recent call last):",
+                "  File \"app.py\", line 1, in <module>",
+                "RuntimeError: failed with sk-1234567890abcdef",
+            ],
+        )
+        captured = capsys.readouterr()
+        import json
+
+        rec = json.loads(captured.err)
+        assert rec["stacktrace"] == [
+            "Traceback (most recent call last):",
+            "  File \"app.py\", line 1, in <module>",
+            "RuntimeError: failed with **********",
+        ]
+        assert "sk-1234567890abcdef" not in captured.err
+
     def test_level_validation(self):
         from mcp_gateway.audit.logger import AuditLogger
 

--- a/tests/unit/test_mcp_gateway.py
+++ b/tests/unit/test_mcp_gateway.py
@@ -513,7 +513,7 @@ class TestAuditLogger:
             level="ERROR",
             stacktrace=[
                 "Traceback (most recent call last):",
-                "  File \"app.py\", line 1, in <module>",
+                '  File "app.py", line 1, in <module>',
                 "RuntimeError: failed with sk-1234567890abcdef",
             ],
         )
@@ -523,7 +523,7 @@ class TestAuditLogger:
         rec = json.loads(captured.err)
         assert rec["stacktrace"] == [
             "Traceback (most recent call last):",
-            "  File \"app.py\", line 1, in <module>",
+            '  File "app.py", line 1, in <module>',
             "RuntimeError: failed with **********",
         ]
         assert "sk-1234567890abcdef" not in captured.err


### PR DESCRIPTION
## Summary
- `stacktrace` / `traceback` フィールドはログ全体を `**********` に置換せず、機微パターンに一致した部分だけをマスクするよう修正。
- worktree パスに `sk-...` 形式の断片が含まれる場合でも、監査ログのスタックトレース本文を保持します。

## Test plan
- [x] `uv run pytest tests/unit/test_mcp_gateway.py::TestAuditLogger::test_startup_failure_log_content tests/unit/test_mcp_gateway.py::TestAuditLogger::test_audit_log_value_redaction tests/unit/test_mcp_gateway.py::TestAuditLogger::test_recursive_sensitive_field_masking -v`
- [x] `uv run ruff check src/mcp_gateway/audit/logger.py`
- [x] `uv run ruff format --check src/mcp_gateway/audit/logger.py`
- [x] `uv run mypy src/mcp_gateway/audit/logger.py`
- [x] `uv run pytest tests/unit -v -x`