### PR TITLE
feat(shared): ingestion mode SSOT を追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ module = "yaml.*"
 ignore_missing_imports = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/context_store", "src/mcp_gateway"]
+packages = ["src/context_store", "src/mcp_gateway", "src/chronos_shared"]
 
 [dependency-groups]
 dev = [

--- a/src/chronos_shared/ingestion_mode.py
+++ b/src/chronos_shared/ingestion_mode.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Final, Literal
 
+__all__ = ["IngestionMode", "DEFAULT_INGESTION_MODE", "CHRONOS_INGESTION_MODE_ENV"]
+
 IngestionMode = Literal["all", "selective"]
 DEFAULT_INGESTION_MODE: Final[IngestionMode] = "selective"
 CHRONOS_INGESTION_MODE_ENV: Final[str] = "CHRONOS_INGESTION_MODE"

--- a/src/chronos_shared/ingestion_mode.py
+++ b/src/chronos_shared/ingestion_mode.py
@@ -1,0 +1,21 @@
+"""SSOT for the ``CHRONOS_INGESTION_MODE`` environment variable.
+
+This module is the single source of truth for the type, default value, and
+environment variable name of the hybrid ingestion mode setting. Both
+``context_store.config.Settings`` and ``mcp_gateway.config.GatewaySettings``
+import from here to guarantee consistency across the two independent
+processes.
+
+Placement rationale: ``mcp_gateway/upstream/context_store_client.py`` enforces
+"the gateway must NOT import anything from ``context_store``". Placing this
+SSOT under either subsystem would force a cross-package import. Hence the
+module lives in its own top-level package ``chronos_shared``.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+IngestionMode = Literal["all", "selective"]
+DEFAULT_INGESTION_MODE: Final[IngestionMode] = "selective"
+CHRONOS_INGESTION_MODE_ENV: Final[str] = "CHRONOS_INGESTION_MODE"

--- a/src/chronos_shared/ingestion_mode.py
+++ b/src/chronos_shared/ingestion_mode.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Final, Literal
 
-__all__ = ["IngestionMode", "DEFAULT_INGESTION_MODE", "CHRONOS_INGESTION_MODE_ENV"]
+__all__ = ["CHRONOS_INGESTION_MODE_ENV", "DEFAULT_INGESTION_MODE", "IngestionMode"]
 
 IngestionMode = Literal["all", "selective"]
 DEFAULT_INGESTION_MODE: Final[IngestionMode] = "selective"

--- a/tests/unit/test_chronos_shared_ingestion_mode.py
+++ b/tests/unit/test_chronos_shared_ingestion_mode.py
@@ -1,0 +1,36 @@
+"""chronos_shared.ingestion_mode の SSOT 契約検証。"""
+
+from __future__ import annotations
+
+from typing import get_args
+
+
+def test_default_ingestion_mode_is_selective() -> None:
+    from chronos_shared.ingestion_mode import DEFAULT_INGESTION_MODE
+
+    assert DEFAULT_INGESTION_MODE == "selective"
+
+
+def test_env_var_name_is_chronos_ingestion_mode() -> None:
+    from chronos_shared.ingestion_mode import CHRONOS_INGESTION_MODE_ENV
+
+    assert CHRONOS_INGESTION_MODE_ENV == "CHRONOS_INGESTION_MODE"
+
+
+def test_ingestion_mode_literal_has_exactly_two_values() -> None:
+    """`IngestionMode` は Literal["all", "selective"] であること。"""
+    from chronos_shared.ingestion_mode import IngestionMode
+
+    assert set(get_args(IngestionMode)) == {"all", "selective"}
+
+
+def test_module_exposes_only_three_public_symbols() -> None:
+    """SSOT モジュールは 3 シンボルのみ公開する (それ以外は意図しない拡張)。"""
+    import chronos_shared.ingestion_mode as mod
+
+    public = {name for name in dir(mod) if not name.startswith("_")}
+    expected = {"CHRONOS_INGESTION_MODE_ENV", "DEFAULT_INGESTION_MODE", "IngestionMode"}
+    assert expected.issubset(public)
+    allowed = expected | {"annotations", "Final", "Literal"}
+    extras = public - allowed
+    assert extras == set(), f"unexpected public symbols: {extras}"


### PR DESCRIPTION
## Summary
- CHRONOS_INGESTION_MODE の SSOT として chronos_shared.ingestion_mode を追加。
- wheel package に chronos_shared を追加。

## Test plan
- [x] uv run pytest tests/unit/test_chronos_shared_ingestion_mode.py -v
- [x] uv run ruff check src/chronos_shared tests/unit/test_chronos_shared_ingestion_mode.py
- [x] uv run mypy src/chronos_shared tests/unit/test_chronos_shared_ingestion_mode.py