### PR TITLE
feat(scripts): ターン終了フックを追加

### DIFF
--- a/scripts/agent_turn_hook.py
+++ b/scripts/agent_turn_hook.py
@@ -32,6 +32,9 @@ TRUNCATION_MARKER_TEMPLATE: Final[str] = "[truncated to last {n} bytes]\n"
 
 def truncate_log(content: str, max_bytes: int) -> tuple[str, bool]:
     """会話ログを送信前に末尾保持で切り詰める純関数。"""
+    if max_bytes <= 0:
+        return "", True
+
     encoded = content.encode("utf-8")
     if len(encoded) <= max_bytes:
         return content, False
@@ -172,7 +175,9 @@ async def _main_async(payload: str) -> None:
 
 
 def main() -> int:
-    log_level = os.environ.get("LOG_LEVEL", "INFO")
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    if log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        log_level = "INFO"
     logging.basicConfig(level=log_level, format=LOG_FORMAT, stream=sys.stderr)
 
     parser = _build_parser()

--- a/scripts/agent_turn_hook.py
+++ b/scripts/agent_turn_hook.py
@@ -1,0 +1,209 @@
+"""ターン終了時に会話ログを MCP Gateway へ fire-and-forget で送信するフック。
+
+呼び出し例:
+    echo "$CONVERSATION_LOG" | python scripts/agent_turn_hook.py &
+    # または
+    python scripts/agent_turn_hook.py --content "..." &
+
+設計書: docs/superpowers/specs/2026-05-27-hybrid-ingestion-mode-design.md §4.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from typing import Final
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+
+LOG_FORMAT: Final[str] = "%(asctime)s [%(levelname)s] agent_turn_hook: %(message)s"
+
+DEFAULT_GATEWAY_URL: Final[str] = "http://127.0.0.1:9100"
+DEFAULT_INTENT: Final[str] = "memory.ingest"
+DEFAULT_TIMEOUT_SECONDS: Final[float] = 2.0
+DEFAULT_SSE_TIMEOUT_SECONDS: Final[float] = 1.0
+DEFAULT_MAX_LOG_BYTES: Final[int] = 8 * 1024 * 1024
+TRUNCATION_MARKER_TEMPLATE: Final[str] = "[truncated to last {n} bytes]\n"
+
+
+def truncate_log(content: str, max_bytes: int) -> tuple[str, bool]:
+    """会話ログを送信前に末尾保持で切り詰める純関数。"""
+    encoded = content.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return content, False
+
+    marker = TRUNCATION_MARKER_TEMPLATE.format(n=max_bytes)
+    marker_bytes = marker.encode("utf-8")
+    tail_budget = max_bytes - len(marker_bytes)
+    if tail_budget <= 0:
+        return marker_bytes[:max_bytes].decode("utf-8", errors="ignore"), True
+
+    tail = encoded[-tail_budget:].decode("utf-8", errors="ignore")
+    return marker + tail, True
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="ChronosGraph turn-end memory ingestion hook")
+    parser.add_argument(
+        "--content",
+        default=None,
+        help="会話ログ本文。未指定時は stdin から読み取る。",
+    )
+    return parser
+
+
+def _read_input(args: argparse.Namespace) -> str:
+    content = args.content
+    if isinstance(content, str):
+        return content
+    return sys.stdin.read()
+
+
+def _extract_session_id(data_line: str) -> str | None:
+    """SSE の ``data: /messages?session_id=XXX&...`` 行から session_id を取り出す。"""
+    if not data_line.startswith("data: "):
+        return None
+    payload = data_line[len("data: ") :].strip()
+    parsed = urlparse(payload)
+    values = parse_qs(parsed.query).get("session_id") or []
+    return values[0] if values else None
+
+
+async def _sse_handshake(
+    client: httpx.AsyncClient, gateway_url: str, headers: dict[str, str]
+) -> str | None:
+    """SSE エンドポイントから最初の session_id を取得して切断する。"""
+    async with client.stream("GET", f"{gateway_url}/sse", headers=headers) as resp:
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if line.startswith("data: ") and "session_id=" in line:
+                return _extract_session_id(line)
+    return None
+
+
+async def _post_tools_call(
+    client: httpx.AsyncClient,
+    gateway_url: str,
+    session_id: str,
+    payload: str,
+    headers: dict[str, str],
+) -> None:
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "memory_save",
+            "arguments": {"content": payload},
+        },
+    }
+    post_resp = await client.post(
+        f"{gateway_url}/messages",
+        params={"session_id": session_id},
+        json=body,
+        headers={"content-type": "application/json", **headers},
+    )
+    if post_resp.status_code == 413:
+        logging.warning(
+            "Gateway returned 413 Payload Too Large; "
+            "consider lowering MCP_HOOK_MAX_LOG_BYTES (currently %d)",
+            int(os.environ.get("MCP_HOOK_MAX_LOG_BYTES", DEFAULT_MAX_LOG_BYTES)),
+        )
+    elif post_resp.status_code >= 400:
+        logging.warning("Gateway returned HTTP %d", post_resp.status_code)
+
+
+async def _send(
+    gateway_url: str,
+    api_key: str,
+    intent: str,
+    payload: str,
+    total_timeout: float,
+    sse_timeout: float,
+) -> None:
+    """SSE handshake 後に ``tools/call memory_save`` を送信する。"""
+    headers = {
+        "authorization": f"Bearer {api_key}",
+        "x-mcp-intent": intent,
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(total_timeout, connect=1.0)) as client:
+        try:
+            session_id = await asyncio.wait_for(
+                _sse_handshake(client, gateway_url, headers),
+                timeout=sse_timeout,
+            )
+        except TimeoutError:
+            logging.info("SSE handshake timed out after %.2fs", sse_timeout)
+            return
+
+        if session_id is None:
+            logging.warning("SSE handshake did not yield a session_id")
+            return
+
+        await _post_tools_call(client, gateway_url, session_id, payload, headers)
+
+
+async def _main_async(payload: str) -> None:
+    gateway_url = os.environ.get("MCP_GATEWAY_URL", DEFAULT_GATEWAY_URL)
+    api_key = os.environ.get("MCP_GATEWAY_API_KEY")
+    intent = os.environ.get("MCP_INTENT", DEFAULT_INTENT)
+    total_timeout = float(os.environ.get("MCP_HOOK_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    sse_timeout = float(os.environ.get("MCP_HOOK_SSE_TIMEOUT_SECONDS", DEFAULT_SSE_TIMEOUT_SECONDS))
+
+    if not api_key:
+        logging.error("MCP_GATEWAY_API_KEY is not set; aborting hook (no-op)")
+        return
+
+    try:
+        await asyncio.wait_for(
+            _send(gateway_url, api_key, intent, payload, total_timeout, sse_timeout),
+            timeout=total_timeout,
+        )
+    except TimeoutError as exc:
+        logging.info("turn hook timed out (total budget exhausted): %s", exc)
+    except httpx.HTTPError as exc:
+        logging.warning("turn hook failed (HTTP error): %s", exc)
+    except Exception as exc:  # noqa: BLE001 - intentional broad catch
+        logging.warning("turn hook failed (unexpected): %s", exc, exc_info=True)
+
+
+def main() -> int:
+    log_level = os.environ.get("LOG_LEVEL", "INFO")
+    logging.basicConfig(level=log_level, format=LOG_FORMAT, stream=sys.stderr)
+
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        raw = _read_input(args)
+    except Exception as exc:  # noqa: BLE001 - intentional broad catch
+        logging.warning("failed to read input: %s", exc)
+        return 0
+
+    if not raw:
+        logging.debug("empty input; skipping hook invocation")
+        return 0
+
+    max_bytes = int(os.environ.get("MCP_HOOK_MAX_LOG_BYTES", DEFAULT_MAX_LOG_BYTES))
+    payload, was_truncated = truncate_log(raw, max_bytes)
+    if was_truncated:
+        logging.warning(
+            "payload truncated: original=%d bytes, sent=%d bytes",
+            len(raw.encode("utf-8")),
+            len(payload.encode("utf-8")),
+        )
+
+    try:
+        asyncio.run(_main_async(payload))
+    except Exception as exc:  # noqa: BLE001 - intentional broad catch
+        logging.warning("turn hook failed at top level: %s", exc, exc_info=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_agent_turn_hook_truncate.py
+++ b/tests/unit/test_agent_turn_hook_truncate.py
@@ -1,0 +1,100 @@
+"""scripts/agent_turn_hook.py の pure helpers (truncate_log / _extract_session_id) の検証。"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_hook_module():
+    """scripts/agent_turn_hook.py を tests から動的に import するヘルパ。"""
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "agent_turn_hook.py"
+    spec = importlib.util.spec_from_file_location("agent_turn_hook", script_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["agent_turn_hook"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_truncate_log_short_input_returns_unchanged() -> None:
+    mod = _load_hook_module()
+    text = "hello world"
+    out, was_truncated = mod.truncate_log(text, max_bytes=1024)
+    assert out == text
+    assert was_truncated is False
+
+
+def test_truncate_log_long_ascii_input_keeps_tail() -> None:
+    mod = _load_hook_module()
+    text = "a" * 5000
+    out, was_truncated = mod.truncate_log(text, max_bytes=1024)
+    assert was_truncated is True
+    assert len(out.encode("utf-8")) <= 1024
+    assert out.endswith("a")
+    assert out.startswith("[truncated to last ")
+
+
+def test_truncate_log_marker_is_prefixed_and_bytes_stay_under_limit() -> None:
+    mod = _load_hook_module()
+    text = "x" * 10_000
+    max_bytes = 200
+    out, was_truncated = mod.truncate_log(text, max_bytes=max_bytes)
+    assert was_truncated is True
+    assert len(out.encode("utf-8")) <= max_bytes
+    assert "[truncated to last " in out.splitlines()[0]
+
+
+def test_truncate_log_multibyte_utf8_does_not_corrupt() -> None:
+    """日本語 (3 バイト/文字) を含む長文を切り詰めても、不完全シーケンスを残さない。"""
+    mod = _load_hook_module()
+    text = "あ" * 1000
+    out, was_truncated = mod.truncate_log(text, max_bytes=500)
+    assert was_truncated is True
+    out.encode("utf-8").decode("utf-8")
+    assert len(out.encode("utf-8")) <= 500
+
+
+def test_truncate_log_exactly_at_limit_is_not_truncated() -> None:
+    mod = _load_hook_module()
+    text = "y" * 100
+    out, was_truncated = mod.truncate_log(text, max_bytes=100)
+    assert was_truncated is False
+    assert out == text
+
+
+def test_truncate_log_max_bytes_smaller_than_marker_returns_truncated_marker() -> None:
+    """max_bytes がマーカー長より小さい異常ケース。バイト境界で切り詰めて返す。"""
+    mod = _load_hook_module()
+    text = "z" * 1000
+    out, was_truncated = mod.truncate_log(text, max_bytes=5)
+    assert was_truncated is True
+    assert len(out.encode("utf-8")) <= 5
+    out.encode("utf-8").decode("utf-8")
+
+
+def test_extract_session_id_simple_data_line() -> None:
+    """典型的な SSE 1 行から session_id を取り出せること。"""
+    mod = _load_hook_module()
+    sid = mod._extract_session_id("data: /messages?session_id=abc123")
+    assert sid == "abc123"
+
+
+def test_extract_session_id_ignores_additional_query_params() -> None:
+    """Issue 1: 追加クエリパラメータが付いても session_id だけが返ること。"""
+    mod = _load_hook_module()
+    sid = mod._extract_session_id("data: /messages?session_id=abc123&trace_id=xyz&foo=bar")
+    assert sid == "abc123"
+
+
+def test_extract_session_id_returns_none_for_non_data_line() -> None:
+    mod = _load_hook_module()
+    assert mod._extract_session_id("event: ping") is None
+    assert mod._extract_session_id("") is None
+
+
+def test_extract_session_id_returns_none_when_param_missing() -> None:
+    mod = _load_hook_module()
+    assert mod._extract_session_id("data: /messages?foo=bar") is None

--- a/tests/unit/test_agent_turn_hook_truncate.py
+++ b/tests/unit/test_agent_turn_hook_truncate.py
@@ -9,6 +9,8 @@ import sys
 
 def _load_hook_module():
     """scripts/agent_turn_hook.py を tests から動的に import するヘルパ。"""
+    if "agent_turn_hook" in sys.modules:
+        return sys.modules["agent_turn_hook"]
     repo_root = pathlib.Path(__file__).resolve().parents[2]
     script_path = repo_root / "scripts" / "agent_turn_hook.py"
     spec = importlib.util.spec_from_file_location("agent_turn_hook", script_path)
@@ -98,3 +100,19 @@ def test_extract_session_id_returns_none_for_non_data_line() -> None:
 def test_extract_session_id_returns_none_when_param_missing() -> None:
     mod = _load_hook_module()
     assert mod._extract_session_id("data: /messages?foo=bar") is None
+
+
+def test_truncate_log_max_bytes_non_positive_returns_empty_and_truncated() -> None:
+    """max_bytes が 0 または負の値の場合、空文字列と True を返すこと。"""
+    mod = _load_hook_module()
+    text = "hello world"
+
+    # 0 の場合
+    out, was_truncated = mod.truncate_log(text, max_bytes=0)
+    assert out == ""
+    assert was_truncated is True
+
+    # 負の値の場合
+    out, was_truncated = mod.truncate_log(text, max_bytes=-5)
+    assert out == ""
+    assert was_truncated is True


### PR DESCRIPTION
## Summary
- scripts/agent_turn_hook.py を追加し、会話ログを Gateway に fire-and-forget 送信する基盤を実装。
- truncate_log と session_id extraction の unit tests を追加。

## Test plan
- [x] uv run pytest tests/unit/test_agent_turn_hook_truncate.py -v
- [x] uv run ruff check scripts/agent_turn_hook.py tests/unit/test_agent_turn_hook_truncate.py
- [x] uv run mypy scripts/agent_turn_hook.py tests/unit/test_agent_turn_hook_truncate.py
- [x] uv run python scripts/agent_turn_hook.py --help