### PR TITLE
feat(gateway): ToolRegistry に hidden_tools を追加

### DIFF
--- a/src/mcp_gateway/tools/registry.py
+++ b/src/mcp_gateway/tools/registry.py
@@ -7,15 +7,25 @@ from typing import AbstractSet, Any
 
 
 class ToolRegistry:
-    def __init__(self, all_tools: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        all_tools: list[dict[str, Any]],
+        *,
+        hidden_tools: AbstractSet[str] = frozenset(),
+    ) -> None:
         self._all = copy.deepcopy(all_tools)
+        self._hidden: frozenset[str] = frozenset(hidden_tools)
 
     @property
     def all_tools(self) -> list[dict[str, Any]]:
-        return copy.deepcopy(self._all)
+        return [copy.deepcopy(t) for t in self._all if t.get("name") not in self._hidden]
 
     def filter_by_caps(self, *, caps: AbstractSet[str]) -> list[dict[str, Any]]:
-        return [copy.deepcopy(t) for t in self._all if t.get("name") in caps]
+        return [
+            copy.deepcopy(t)
+            for t in self._all
+            if t.get("name") in caps and t.get("name") not in self._hidden
+        ]
 
     def replace_tools(self, all_tools: list[dict[str, Any]]) -> None:
         self._all = copy.deepcopy(all_tools)

--- a/tests/unit/test_tool_registry_hidden.py
+++ b/tests/unit/test_tool_registry_hidden.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mcp_gateway.tools.registry import ToolRegistry
 
 
@@ -57,8 +59,6 @@ def test_replace_tools_does_not_clear_hidden_tools() -> None:
 
 def test_hidden_tools_keyword_only_argument() -> None:
     """hidden_tools は keyword-only argument として渡される (誤って positional で渡せない)。"""
-    import pytest
-
     tools = [_make_tool("memory_save")]
     with pytest.raises(TypeError):
         ToolRegistry(tools, frozenset({"memory_save"}))  # type: ignore[misc]

--- a/tests/unit/test_tool_registry_hidden.py
+++ b/tests/unit/test_tool_registry_hidden.py
@@ -1,0 +1,64 @@
+"""ToolRegistry.hidden_tools のフィルタ挙動検証。"""
+
+from __future__ import annotations
+
+from mcp_gateway.tools.registry import ToolRegistry
+
+
+def _make_tool(name: str) -> dict[str, object]:
+    return {"name": name, "description": f"tool {name}", "inputSchema": {"type": "object"}}
+
+
+def test_default_hidden_tools_is_empty_and_preserves_all_tools() -> None:
+    """hidden_tools 未指定時は従来通り全 tool を保持する (後方互換)。"""
+    tools = [_make_tool("memory_save"), _make_tool("memory_search")]
+    r = ToolRegistry(tools)
+    names = [t["name"] for t in r.all_tools]
+    assert names == ["memory_save", "memory_search"]
+
+
+def test_hidden_tools_excludes_named_tools_from_all_tools() -> None:
+    tools = [
+        _make_tool("memory_save"),
+        _make_tool("memory_save_url"),
+        _make_tool("memory_search"),
+    ]
+    r = ToolRegistry(tools, hidden_tools=frozenset({"memory_save"}))
+    names = [t["name"] for t in r.all_tools]
+    assert "memory_save" not in names
+    assert {"memory_save_url", "memory_search"} == set(names)
+
+
+def test_hidden_tools_excludes_named_tools_from_filter_by_caps() -> None:
+    tools = [_make_tool("memory_save"), _make_tool("memory_search")]
+    r = ToolRegistry(tools, hidden_tools=frozenset({"memory_save"}))
+    filtered = r.filter_by_caps(caps={"memory_save", "memory_search"})
+    names = [t["name"] for t in filtered]
+    assert names == ["memory_search"]
+
+
+def test_hidden_tools_unknown_names_are_silently_ignored() -> None:
+    """存在しない tool 名を hidden_tools に渡しても警告無く何も除外しない。"""
+    tools = [_make_tool("memory_save")]
+    r = ToolRegistry(tools, hidden_tools=frozenset({"nonexistent_tool"}))
+    names = [t["name"] for t in r.all_tools]
+    assert names == ["memory_save"]
+
+
+def test_replace_tools_does_not_clear_hidden_tools() -> None:
+    """replace_tools は _all のみ差し替え、hidden_tools は不変。"""
+    initial = [_make_tool("memory_save")]
+    r = ToolRegistry(initial, hidden_tools=frozenset({"memory_save"}))
+    r.replace_tools([_make_tool("memory_save"), _make_tool("memory_search")])
+    names = [t["name"] for t in r.all_tools]
+    assert "memory_save" not in names
+    assert "memory_search" in names
+
+
+def test_hidden_tools_keyword_only_argument() -> None:
+    """hidden_tools は keyword-only argument として渡される (誤って positional で渡せない)。"""
+    import pytest
+
+    tools = [_make_tool("memory_save")]
+    with pytest.raises(TypeError):
+        ToolRegistry(tools, frozenset({"memory_save"}))  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- ToolRegistry に hidden_tools keyword-only 引数を追加。
- all_tools / filter_by_caps から hidden tool を除外。

## Test plan
- [x] uv run pytest tests/unit/test_tool_registry_hidden.py -v
- [x] uv run ruff check src/mcp_gateway/tools/registry.py tests/unit/test_tool_registry_hidden.py
- [x] uv run mypy src/mcp_gateway/tools/registry.py tests/unit/test_tool_registry_hidden.py