### PR TITLE
chore(outbox): Phase Root - sync パッケージ初期化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,3 +260,13 @@ MCP_INTENT=memory.ingest
 MCP_HOOK_TIMEOUT_SECONDS=2.0
 MCP_HOOK_SSE_TIMEOUT_SECONDS=1.0
 MCP_HOOK_MAX_LOG_BYTES=8388608
+
+# --- Graph Sync Mode (rev.11 Transactional Outbox) ---
+# sync: GraphLinker が Neo4j に直接同期書き込み (デフォルト)
+# async_outbox: Storage TX 内で Outbox に書き込み、Worker が非同期で Neo4j 同期
+GRAPH_SYNC_MODE=sync
+OUTBOX_POLL_INTERVAL_SECONDS=5.0
+OUTBOX_BATCH_SIZE=100
+OUTBOX_MAX_RETRIES=10
+OUTBOX_BACKOFF_BASE_SECONDS=1.0
+OUTBOX_BACKOFF_MAX_SECONDS=60.0

--- a/src/context_store/sync/__init__.py
+++ b/src/context_store/sync/__init__.py
@@ -1,0 +1,8 @@
+"""Transactional Outbox Sync package.
+
+Provides:
+- OutboxWriter: Storage TX 内で Outbox レコードを書き込む
+- OutboxReader: Outbox からイベントを取得・更新する
+- OutboxWorker: ポーリングループでイベントを処理する
+- GraphSyncService: Storage → Neo4j の MERGE ロジック (Worker + リカバリ共有)
+"""

--- a/src/context_store/sync/models.py
+++ b/src/context_store/sync/models.py
@@ -10,6 +10,8 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 EventType = Literal["SYNC_MEMORY", "DELETE_MEMORY"]
+# 正常処理されたイベントは OutboxWorker によって物理削除されるため (Delete-on-Success)、
+# "DONE" / "COMPLETED" などの成功ステータスは定義していません。
 EventStatus = Literal["PENDING", "PROCESSING", "FAILED"]
 
 

--- a/src/context_store/sync/models.py
+++ b/src/context_store/sync/models.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 from typing import Any, Literal, Mapping
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 EventType = Literal["SYNC_MEMORY", "DELETE_MEMORY"]
 # 正常処理されたイベントは OutboxWorker によって物理削除されるため (Delete-on-Success)、
@@ -45,8 +45,13 @@ class OutboxEvent(BaseModel):
             return dt.astimezone(timezone.utc)
         return v
 
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
-        # frozen=True なので object.__setattr__ を使って MappingProxyType に置き換える
-        if not isinstance(self.payload, MappingProxyType):
-            object.__setattr__(self, "payload", MappingProxyType(self.payload))
+    @field_validator("payload", mode="after")
+    @classmethod
+    def freeze_payload(cls, v: Mapping[str, Any]) -> MappingProxyType[str, Any]:
+        if isinstance(v, MappingProxyType):
+            return v
+        return MappingProxyType(dict(v))
+
+    @field_serializer("payload")
+    def serialize_payload(self, v: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(v)

--- a/src/context_store/sync/models.py
+++ b/src/context_store/sync/models.py
@@ -2,25 +2,49 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Literal
+from datetime import datetime, timezone
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 EventType = Literal["SYNC_MEMORY", "DELETE_MEMORY"]
 EventStatus = Literal["PENDING", "PROCESSING", "FAILED"]
 
 
-@dataclass(frozen=True)
-class OutboxEvent:
+class OutboxEvent(BaseModel):
     """Outbox テーブルの 1 レコードを表す不変オブジェクト。"""
 
-    id: str
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
     event_type: EventType
-    memory_id: str
-    payload: dict[str, Any]
-    status: EventStatus
-    retry_count: int
+    memory_id: UUID
+    payload: Mapping[str, Any] = Field(default_factory=dict)
+    status: EventStatus = "PENDING"
+    retry_count: int = Field(default=0, ge=0)
     next_retry_at: datetime
-    error_message: str | None
+    error_message: str | None = None
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("next_retry_at", "created_at", "updated_at", mode="before")
+    @classmethod
+    def ensure_utc(cls, v: Any) -> Any:
+        if isinstance(v, datetime):
+            if v.tzinfo is None:
+                return v.replace(tzinfo=timezone.utc)
+            return v.astimezone(timezone.utc)
+        elif isinstance(v, str):
+            dt = datetime.fromisoformat(v.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
+        return v
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        # frozen=True なので object.__setattr__ を使って MappingProxyType に置き換える
+        if not isinstance(self.payload, MappingProxyType):
+            object.__setattr__(self, "payload", MappingProxyType(self.payload))

--- a/src/context_store/sync/models.py
+++ b/src/context_store/sync/models.py
@@ -1,0 +1,26 @@
+"""Outbox イベントデータモデル。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+EventType = Literal["SYNC_MEMORY", "DELETE_MEMORY"]
+EventStatus = Literal["PENDING", "PROCESSING", "FAILED"]
+
+
+@dataclass(frozen=True)
+class OutboxEvent:
+    """Outbox テーブルの 1 レコードを表す不変オブジェクト。"""
+
+    id: str
+    event_type: EventType
+    memory_id: str
+    payload: dict[str, Any]
+    status: EventStatus
+    retry_count: int
+    next_retry_at: datetime
+    error_message: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/tests/unit/sync/test_models.py
+++ b/tests/unit/sync/test_models.py
@@ -1,0 +1,93 @@
+"""sync.models: OutboxEvent モデルのバリデーションと不変性テスト。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import MappingProxyType
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from context_store.sync.models import OutboxEvent
+
+
+def test_outbox_event_validation_and_coercion() -> None:
+    event_id = uuid4()
+    mem_id = uuid4()
+
+    # 正常なデータでの初期化と型変換の確認
+    event = OutboxEvent(
+        id=str(event_id),  # 文字列からの UUID 変換を確認
+        event_type="SYNC_MEMORY",
+        memory_id=str(mem_id),  # 文字列からの UUID 変換を確認
+        payload={"key": "value"},
+        status="PENDING",
+        retry_count=0,
+        next_retry_at=datetime(2026, 6, 1, 12, 0, 0),  # naive datetime
+        created_at="2026-06-01T12:00:00",  # ISO文字列
+        updated_at=datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc),  # aware datetime
+    )
+
+    assert isinstance(event.id, UUID)
+    assert event.id == event_id
+    assert isinstance(event.memory_id, UUID)
+    assert event.memory_id == mem_id
+
+    # タイムゾーンの強制確認 (UTC に統一されていること)
+    assert event.next_retry_at.tzinfo == timezone.utc
+    assert event.created_at.tzinfo == timezone.utc
+    assert event.updated_at.tzinfo == timezone.utc
+
+    # 不変性 (frozen) の検証
+    with pytest.raises(ValidationError if hasattr(pytest, "ValidationError") else Exception):
+        # frozen=True なので属性への直接代入は不可
+        event.status = "PROCESSING"  # type: ignore
+
+
+def test_outbox_event_payload_immutability() -> None:
+    event = OutboxEvent(
+        id=uuid4(),
+        event_type="SYNC_MEMORY",
+        memory_id=uuid4(),
+        payload={"nested": {"data": 123}, "list": [1, 2, 3]},
+        status="PENDING",
+        next_retry_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    # payload が MappingProxyType でラップされていることの確認
+    assert isinstance(event.payload, MappingProxyType)
+
+    # payload への変更がブロックされることの検証
+    with pytest.raises(TypeError):
+        event.payload["new_key"] = "forbidden"  # type: ignore
+
+    with pytest.raises(TypeError):
+        del event.payload["nested"]  # type: ignore
+
+
+def test_outbox_event_invalid_inputs() -> None:
+    # 不正な event_type
+    with pytest.raises(ValidationError):
+        OutboxEvent(
+            id=uuid4(),
+            event_type="INVALID_TYPE",  # type: ignore
+            memory_id=uuid4(),
+            next_retry_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    # 不正な status
+    with pytest.raises(ValidationError):
+        OutboxEvent(
+            id=uuid4(),
+            event_type="SYNC_MEMORY",
+            memory_id=uuid4(),
+            status="INVALID_STATUS",  # type: ignore
+            next_retry_at=datetime.now(timezone.utc),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )

--- a/tests/unit/sync/test_models.py
+++ b/tests/unit/sync/test_models.py
@@ -40,7 +40,7 @@ def test_outbox_event_validation_and_coercion() -> None:
     assert event.updated_at.tzinfo == timezone.utc
 
     # 不変性 (frozen) の検証
-    with pytest.raises(ValidationError if hasattr(pytest, "ValidationError") else Exception):
+    with pytest.raises(ValidationError):
         # frozen=True なので属性への直接代入は不可
         event.status = "PROCESSING"  # type: ignore
 
@@ -59,6 +59,10 @@ def test_outbox_event_payload_immutability() -> None:
 
     # payload が MappingProxyType でラップされていることの確認
     assert isinstance(event.payload, MappingProxyType)
+
+    # model_validate 経由での復元時も MappingProxyType でラップされていることの検証
+    validated_event = OutboxEvent.model_validate(event.model_dump())
+    assert isinstance(validated_event.payload, MappingProxyType)
 
     # payload への変更がブロックされることの検証
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary
- Transactional Outbox Sync 実装の Phase Root ブランチ。
- `src/context_store/sync/` パッケージとデータモデル `OutboxEvent` を追加。
- `.env.example` に `GRAPH_SYNC_MODE`/`OUTBOX_*` 環境変数のテンプレートを追記。

## Scope
本 PR はパッケージ骨格のみ。実ロジックは後続 PR で stack される。

## Test plan
- [ ] CI: ruff/mypy/pytest が全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)