### PR TITLE
feat(sandbox): テスト用 context_store_test データベースを init.sql に追加

### DIFF
--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -2,3 +2,12 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_bigm;
 
 \i /docker-entrypoint-initdb.d/schema.sql
+-- Test database for sandbox integration tests
+CREATE DATABASE context_store_test;
+GRANT ALL PRIVILEGES ON DATABASE context_store_test TO context_store;
+
+-- Switch to test database and apply the same schema
+\c context_store_test
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_bigm;
+\i /docker-entrypoint-initdb.d/schema.sql


### PR DESCRIPTION
## 変更内容

docker/postgres/init.sql にテスト用データベースを追加：

- context_store_test DB の作成
- 同じスキーマをテストDBにも適用

## 関連

OpenSandbox導入作業計画 Phase 2, Task 2.2