### PR TITLE
fix(sandbox): 設計乖離の修正 - コード・ドキュメントの整合

### DIFF
--- a/.devcontainer/opensandbox/sandbox.yaml
+++ b/.devcontainer/opensandbox/sandbox.yaml
@@ -40,5 +40,8 @@ profiles:
       # You MUST override them in CI or production environments.
       POSTGRES_PASSWORD: "${TEST_DB_PASSWORD:-dev_password}"
       NEO4J_URI: "${TEST_NEO4J_URI:-bolt://host.docker.internal:7687}"
-      NEO4J_AUTH: "${TEST_NEO4J_AUTH:-neo4j/dev_password}"
+      # NOTE: 本体 Settings (src/context_store/config.py) は NEO4J_USER / NEO4J_PASSWORD を
+      # 個別に読む。結合形式の NEO4J_AUTH は読まれないため分割して渡すこと。
+      NEO4J_USER: "${TEST_NEO4J_USER:-neo4j}"
+      NEO4J_PASSWORD: "${TEST_NEO4J_PASSWORD:-dev_password}"
       REDIS_URL: "${TEST_REDIS_URL:-redis://host.docker.internal:6379}"

--- a/docs/superpowers/plans/2026-06-07-opensandbox-integration.md
+++ b/docs/superpowers/plans/2026-06-07-opensandbox-integration.md
@@ -160,7 +160,8 @@ profiles:
       POSTGRES_USER: "${TEST_DB_USER:-context_store}"
       POSTGRES_PASSWORD: "${TEST_DB_PASSWORD}"
       NEO4J_URI: "${TEST_NEO4J_URI:-bolt://host.docker.internal:7687}"
-      NEO4J_AUTH: "${TEST_NEO4J_AUTH}"
+      NEO4J_USER: "${TEST_NEO4J_USER:-neo4j}"
+      NEO4J_PASSWORD: "${TEST_NEO4J_PASSWORD:-dev_password}"
       REDIS_URL: "${TEST_REDIS_URL:-redis://host.docker.internal:6379}"
 ```
 

--- a/docs/superpowers/plans/2026-06-07-opensandbox-integration.md
+++ b/docs/superpowers/plans/2026-06-07-opensandbox-integration.md
@@ -245,6 +245,13 @@ PR: `feat/opensandbox-p1-task2` → `feat/opensandbox-phase1` (Draft)
 
 Create `scripts/sandbox_runner.py`:
 
+> NOTE: The pseudo-code below uses an illustrative `SandboxClient` API. The actual
+> implementation uses the real OpenSandbox SDK: `SandboxSync` /
+> `ConnectionConfigSync` / `RunCommandOpts`, with `SandboxSync.create(image=,
+> metadata={"profile":...}, connection_config=...)`, `sandbox.commands.run(cmd,
+> opts=RunCommandOpts(working_directory=, envs={"OPENSANDBOX":"1"}))`, and
+> `sandbox.kill()`. See `scripts/sandbox_runner.py` for the source of truth.
+
 ```python
 """OpenSandbox runner for AI agent task execution."""
 
@@ -727,22 +734,20 @@ PR: `feat/opensandbox-p2-task1` → `feat/opensandbox-phase2` (Draft)
 
 Modify `docker/postgres/init.sql` to add test database creation before the schema import:
 
-```sql
-CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS pg_bigm;
+Test database creation cannot live in the static `docker/postgres/init.sql`
+(plain SQL run by psql cannot read the `TEST_DB_NAME` env var). The actual
+implementation keeps `init.sql` minimal (extensions only) and delegates DB
+creation + schema application to `docker/postgres/zz-apply-schema.sh`, which
+honors `TEST_DB_NAME` (default `context_store_test`):
 
--- Apply schema to default database
-\i /docker-entrypoint-initdb.d/schema.sql
-
--- Test database for sandbox integration tests
-CREATE DATABASE context_store_test;
-GRANT ALL PRIVILEGES ON DATABASE context_store_test TO context_store;
+```bash
+# docker/postgres/zz-apply-schema.sh (excerpt)
+apply_schema "${POSTGRES_DB:-context_store}"
+ensure_database "${TEST_DB_NAME:-context_store_test}"
+apply_schema "${TEST_DB_NAME:-context_store_test}"
 
 -- Switch to test database and apply the same schema
-\c context_store_test
-CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS pg_bigm;
-\i /docker-entrypoint-initdb.d/schema.sql
+```
 ```
 
 - [ ] **Step 2: Verify SQL syntax**
@@ -786,40 +791,40 @@ from __future__ import annotations
 
 import os
 
-
-def test_sandbox_aware_sqlite_activates(tmp_path, monkeypatch):
-    """OPENSANDBOX=1 の場合、SQLITE_DB_PATH と SQLITE_GRAPH_PATH が tmp_path に設定される。"""
-    monkeypatch.setenv("OPENSANDBOX", "1")
-    monkeypatch.delenv("SQLITE_DB_PATH", raising=False)
-    monkeypatch.delenv("SQLITE_GRAPH_PATH", raising=False)
-
-    # conftest.py の実際のヘルパー関数を呼び出してフィクスチャロジックを検証
-    from conftest import _apply_sandbox_sqlite_paths
-
-    _apply_sandbox_sqlite_paths(tmp_path, monkeypatch)
-
-    assert os.environ["SQLITE_DB_PATH"] == str(tmp_path / "test.db")
-    assert os.environ["SQLITE_GRAPH_PATH"] == str(tmp_path / "test_graph.db")
+import pytest
 
 
-def test_sandbox_aware_sqlite_inactive_without_env(tmp_path, monkeypatch):
-    """OPENSANDBOX が未設定の場合、SQLITE パスは変更されない。"""
-    monkeypatch.delenv("OPENSANDBOX", raising=False)
-    monkeypatch.delenv("SQLITE_DB_PATH", raising=False)
-    monkeypatch.delenv("SQLITE_GRAPH_PATH", raising=False)
+    @pytest.fixture
+    def sandbox_aware_sqlite_env(
+    clean_env,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+    ) -> None:
+    if request.node.name == "test_sandbox_aware_sqlite_activates":
+        monkeypatch.setenv("OPENSANDBOX", "1")
+    else:
+        monkeypatch.delenv("OPENSANDBOX", raising=False)
 
-    from conftest import _apply_sandbox_sqlite_paths
 
-    _apply_sandbox_sqlite_paths(tmp_path, monkeypatch)
+class TestSandboxAwareSqlite:
+    def test_sandbox_aware_sqlite_activates(self, tmp_path):
+        """OPENSANDBOX=1 の場合、SQLITE_DB_PATH が tmp_path に設定される。"""
+        assert os.environ["SQLITE_DB_PATH"] == str(tmp_path / "test.db")
 
-    assert os.environ.get("SQLITE_DB_PATH") is None
-    assert os.environ.get("SQLITE_GRAPH_PATH") is None
+    def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path):
+        """OPENSANDBOX が未設定の場合、SQLITE パスは変更されない。"""
+        assert os.environ.get("SQLITE_DB_PATH") is None
 ```
+
+- NOTE: The autouse `_sandbox_aware_sqlite` fixture lives in the root
+  `tests/conftest.py`; this test drives it via a local `sandbox_aware_sqlite_env`
+  override (which depends on `clean_env` to force ordering). Only `SQLITE_DB_PATH`
+  is asserted — `SQLITE_GRAPH_PATH` is not used by the codebase (single SQLite file).
 
 - [ ] **Step 2: Run the tests to verify baseline**
 
 Run: `uv run pytest tests/unit/test_conftest_sandbox.py -v`
-Expected: Both tests FAIL — `ImportError: cannot import name '_apply_sandbox_sqlite_paths' from 'conftest'`. This is expected (TDD Red phase); the helper function will be added in Step 3.
+Expected: Tests PASS once the root fixture below is in place.
 
 - [ ] **Step 3: Add the fixture to conftest.py**
 
@@ -830,18 +835,17 @@ import os
 
 # ... existing code ...
 
-def _apply_sandbox_sqlite_paths(tmp_path, monkeypatch):
-    """Apply sandbox-aware SQLite paths when running in OpenSandbox."""
+@pytest.fixture(autouse=True)
+def _sandbox_aware_sqlite(tmp_path, monkeypatch, sandbox_aware_sqlite_env):
+    """Ensure SQLite tests use temp paths inside sandbox (OPENSANDBOX=1 only)."""
     if os.environ.get("OPENSANDBOX") == "1":
         monkeypatch.setenv("SQLITE_DB_PATH", str(tmp_path / "test.db"))
-        monkeypatch.setenv("SQLITE_GRAPH_PATH", str(tmp_path / "test_graph.db"))
-
-
-@pytest.fixture(autouse=True)
-def _sandbox_aware_sqlite(tmp_path, monkeypatch):
-    """Ensure SQLite tests use temp paths inside sandbox."""
-    _apply_sandbox_sqlite_paths(tmp_path, monkeypatch)
 ```
+
+Also update `tests/unit/conftest.py::clean_env` to skip deleting `SQLITE_DB_PATH`
+when `OPENSANDBOX=1`, so the path switch survives regardless of fixture order.
+Only `SQLITE_DB_PATH` is set; there is no `sqlite_graph_path` Settings field, so
+`SQLITE_GRAPH_PATH` would be a no-op and is intentionally omitted.
 
 - [ ] **Step 4: Run full test suite for regression**
 

--- a/docs/superpowers/specs/2026-06-07-opensandbox-integration-design.md
+++ b/docs/superpowers/specs/2026-06-07-opensandbox-integration-design.md
@@ -401,21 +401,22 @@ if __name__ == "__main__":
 Add sandbox-aware fixture to `tests/conftest.py`:
 
 ```python
-def _apply_sandbox_sqlite_paths(tmp_path, monkeypatch):
-    """Apply sandbox-aware SQLite paths when running in OpenSandbox."""
+@pytest.fixture(autouse=True)
+def _sandbox_aware_sqlite(tmp_path, monkeypatch, sandbox_aware_sqlite_env):
+    """Ensure SQLite tests use temp paths inside sandbox."""
     if os.environ.get("OPENSANDBOX") == "1":
         monkeypatch.setenv("SQLITE_DB_PATH", str(tmp_path / "test.db"))
-        monkeypatch.setenv("SQLITE_GRAPH_PATH", str(tmp_path / "test_graph.db"))
-
-
-@pytest.fixture(autouse=True)
-def _sandbox_aware_sqlite(tmp_path, monkeypatch):
-    """Ensure SQLite tests use temp paths inside sandbox."""
-    _apply_sandbox_sqlite_paths(tmp_path, monkeypatch)
 ```
 
 - Only activates when `OPENSANDBOX=1` is set (no impact on existing tests)
-- `sandbox_runner.py` guarantees `OPENSANDBOX=1` in the process environment for **all** sandbox executions (both `lite` and `integration` profiles) via the `env` parameter passed to `client.execute()`
+- NOTE: Only `SQLITE_DB_PATH` is set. The SQLite backend stores both memories
+  and the internal graph in a SINGLE file (`Settings.sqlite_db_path`); there is
+  no separate `sqlite_graph_path` field, so a `SQLITE_GRAPH_PATH` env var would
+  be a no-op and is intentionally NOT set.
+- `tests/unit/conftest.py::clean_env` skips deleting `SQLITE_DB_PATH` when
+  `OPENSANDBOX=1`, so this path switch is not clobbered regardless of autouse
+  fixture ordering.
+- `sandbox_runner.py` guarantees `OPENSANDBOX=1` in the process environment for **all** sandbox executions (both `lite` and `integration` profiles) via the `envs` parameter passed to `sandbox.commands.run()` (real SDK: `SandboxSync` / `RunCommandOpts`, not a `SandboxClient.execute()` call)
 
 ### 5.2 DB Connection for Integration Tests
 

--- a/docs/superpowers/specs/2026-06-07-opensandbox-integration-design.md
+++ b/docs/superpowers/specs/2026-06-07-opensandbox-integration-design.md
@@ -188,7 +188,8 @@ profiles:
       POSTGRES_USER: "${TEST_DB_USER:-context_store}"
       POSTGRES_PASSWORD: "${TEST_DB_PASSWORD}"
       NEO4J_URI: "${TEST_NEO4J_URI:-bolt://host.docker.internal:7687}"
-      NEO4J_AUTH: "${TEST_NEO4J_AUTH}"
+      NEO4J_USER: "${TEST_NEO4J_USER:-neo4j}"
+      NEO4J_PASSWORD: "${TEST_NEO4J_PASSWORD:-dev_password}"
       REDIS_URL: "${TEST_REDIS_URL:-redis://host.docker.internal:6379}"
 ```
 

--- a/scripts/sandbox_runner.py
+++ b/scripts/sandbox_runner.py
@@ -63,6 +63,15 @@ def install_dependencies(
 
 
 def setup_sandbox(connection_config: ConnectionConfigSync, profile: str) -> SandboxSync:
+    # WARNING: profile (lite/integration) is passed ONLY as metadata, plus the
+    # image. The sandbox.yaml profile config (mounts of the project into
+    # /workspace, egress allow-lists, and the integration env block with
+    # POSTGRES_*/NEO4J_*/REDIS_URL) is applied by the OpenSandbox server, which
+    # must resolve these from the mounted config.yaml. If the server does NOT
+    # auto-apply the profile by image/metadata, then /workspace will be empty
+    # and integration DB env vars will be missing. Verify end-to-end via the
+    # plan's Verification Checklist (docs/superpowers/plans/2026-06-07-opensandbox-integration.md)
+    # before relying on integration runs.
     image = PROFILE_IMAGES.get(profile, PROFILE_IMAGES[DEFAULT_PROFILE])
     for attempt in range(MAX_RETRIES + 1):
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,4 +186,3 @@ def _sandbox_aware_sqlite(tmp_path, monkeypatch, sandbox_aware_sqlite_env):
     """
     if os.environ.get("OPENSANDBOX") == "1":
         monkeypatch.setenv("SQLITE_DB_PATH", str(tmp_path / "test.db"))
-        monkeypatch.setenv("SQLITE_GRAPH_PATH", str(tmp_path / "test_graph.db"))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import pytest
@@ -7,9 +8,19 @@ from context_store.config import Settings
 
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """テスト実行前に設定関連の環境変数をクリアする。"""
+    """テスト実行前に設定関連の環境変数をクリアする。
+
+    ただし OPENSANDBOX=1 の場合、ルート conftest の _sandbox_aware_sqlite が
+    設定する SQLITE_DB_PATH は削除しない。delenv するとサンドボックス用の
+    一時 DB パス切り替えが打ち消されてしまうため(fixture 実行順序に依存しない
+    ようここで明示的に除外する)。
+    """
+    sandbox_mode = os.environ.get("OPENSANDBOX") == "1"
     for field_name in Settings.model_fields.keys():
-        monkeypatch.delenv(field_name.upper(), raising=False)
+        env_name = field_name.upper()
+        if sandbox_mode and env_name == "SQLITE_DB_PATH":
+            continue
+        monkeypatch.delenv(env_name, raising=False)
 
 
 def make_settings(**kwargs: Any) -> Settings:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,7 +18,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     sandbox_mode = os.environ.get("OPENSANDBOX") == "1"
     for field_name in Settings.model_fields.keys():
         env_name = field_name.upper()
-        if sandbox_mode and env_name == "SQLITE_DB_PATH":
+        if sandbox_mode and field_name == "sqlite_db_path":
             continue
         monkeypatch.delenv(env_name, raising=False)
 

--- a/tests/unit/test_conftest_sandbox.py
+++ b/tests/unit/test_conftest_sandbox.py
@@ -8,24 +8,31 @@ import pytest
 
 
 @pytest.fixture
-def sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """OPENSANDBOX=1 を設定するフィクスチャ。"""
-    monkeypatch.setenv("OPENSANDBOX", "1")
+def sandbox_aware_sqlite_env(
+    clean_env,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """_sandbox_aware_sqlite の制御用フィクスチャをオーバーライドする。
 
-
-@pytest.fixture
-def no_sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """OPENSANDBOX が未設定の状態を保証するフィクスチャ。"""
-    monkeypatch.delenv("OPENSANDBOX", raising=False)
+    clean_env に依存させることで「clean_env → sandbox_aware_sqlite_env →
+    _sandbox_aware_sqlite」という実行順序を保証する。
+    test_sandbox_aware_sqlite_activates の場合のみ OPENSANDBOX=1 を設定し、
+    他のテストでは未設定状態を保証する。
+    """
+    if request.node.name == "test_sandbox_aware_sqlite_activates":
+        monkeypatch.setenv("OPENSANDBOX", "1")
+    else:
+        monkeypatch.delenv("OPENSANDBOX", raising=False)
 
 
 class TestSandboxAwareSqlite:
     """_sandbox_aware_sqlite fixture の振る舞いを検証する。"""
 
-    def test_sandbox_aware_sqlite_activates(self, tmp_path, clean_env, sandbox_env):
+    def test_sandbox_aware_sqlite_activates(self, tmp_path):
         """OPENSANDBOX=1 の場合、SQLITE_DB_PATH が tmp_path に設定される。"""
         assert os.environ["SQLITE_DB_PATH"] == str(tmp_path / "test.db")
 
-    def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path, clean_env, no_sandbox_env):
+    def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path):
         """OPENSANDBOX が未設定の場合、SQLITE パスは変更されない。"""
         assert os.environ.get("SQLITE_DB_PATH") is None

--- a/tests/unit/test_conftest_sandbox.py
+++ b/tests/unit/test_conftest_sandbox.py
@@ -18,6 +18,7 @@ def no_sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """OPENSANDBOX が未設定の状態を保証するフィクスチャ。"""
     monkeypatch.delenv("OPENSANDBOX", raising=False)
 
+
 class TestSandboxAwareSqlite:
     """_sandbox_aware_sqlite fixture の振る舞いを検証する。"""
 

--- a/tests/unit/test_conftest_sandbox.py
+++ b/tests/unit/test_conftest_sandbox.py
@@ -8,24 +8,23 @@ import pytest
 
 
 @pytest.fixture
-def sandbox_aware_sqlite_env(
-    clean_env,
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-) -> None:
-    if request.node.name == "test_sandbox_aware_sqlite_activates":
-        monkeypatch.setenv("OPENSANDBOX", "1")
-    else:
-        monkeypatch.delenv("OPENSANDBOX", raising=False)
+def sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPENSANDBOX=1 を設定するフィクスチャ。"""
+    monkeypatch.setenv("OPENSANDBOX", "1")
 
+
+@pytest.fixture
+def no_sandbox_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OPENSANDBOX が未設定の状態を保証するフィクスチャ。"""
+    monkeypatch.delenv("OPENSANDBOX", raising=False)
 
 class TestSandboxAwareSqlite:
     """_sandbox_aware_sqlite fixture の振る舞いを検証する。"""
 
-    def test_sandbox_aware_sqlite_activates(self, tmp_path):
+    def test_sandbox_aware_sqlite_activates(self, tmp_path, clean_env, sandbox_env):
         """OPENSANDBOX=1 の場合、SQLITE_DB_PATH が tmp_path に設定される。"""
         assert os.environ["SQLITE_DB_PATH"] == str(tmp_path / "test.db")
 
-    def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path):
+    def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path, clean_env, no_sandbox_env):
         """OPENSANDBOX が未設定の場合、SQLITE パスは変更されない。"""
         assert os.environ.get("SQLITE_DB_PATH") is None

--- a/tests/unit/test_conftest_sandbox.py
+++ b/tests/unit/test_conftest_sandbox.py
@@ -23,11 +23,9 @@ class TestSandboxAwareSqlite:
     """_sandbox_aware_sqlite fixture の振る舞いを検証する。"""
 
     def test_sandbox_aware_sqlite_activates(self, tmp_path):
-        """OPENSANDBOX=1 の場合、SQLITE_DB_PATH と SQLITE_GRAPH_PATH が tmp_path に設定される。"""
+        """OPENSANDBOX=1 の場合、SQLITE_DB_PATH が tmp_path に設定される。"""
         assert os.environ["SQLITE_DB_PATH"] == str(tmp_path / "test.db")
-        assert os.environ["SQLITE_GRAPH_PATH"] == str(tmp_path / "test_graph.db")
 
     def test_sandbox_aware_sqlite_inactive_without_env(self, tmp_path):
         """OPENSANDBOX が未設定の場合、SQLITE パスは変更されない。"""
         assert os.environ.get("SQLITE_DB_PATH") is None
-        assert os.environ.get("SQLITE_GRAPH_PATH") is None


### PR DESCRIPTION
## 概要

設計書/計画書と実装の間で確認されたデータフロー乖離を修正しました。

## 変更内容

### Code (fix)

- **SQLITE_GRAPH_PATH 削除**: `tests/conftest.py` から no-op の `SQLITE_GRAPH_PATH` 設定行を削除。`config.py` に `sqlite_graph_path` フィールドは存在せず、SQLite バックエンドは単一DB設計のため。
- **NEO4J_AUTH 分割**: `sandbox.yaml` の結合形式 `NEO4J_AUTH` を `NEO4J_USER` / `NEO4J_PASSWORD` に分割。本体 `Settings` が個別に読み取る形式に一致。
- **clean_env sandbox対応**: `tests/unit/conftest.py` に `OPENSANDBOX=1` 判定を追加し、サンドボックス実行時に `SQLITE_DB_PATH` が削除されないようにガード。
- **sandbox_runner警告**: `setup_sandbox` に profile 構成(mounts/env)のサーバ側適用が未確認である旨のWARNINGコメントを追記。

### Docs (docs)

- **設計書§5.1**: `SQLITE_GRAPH_PATH` 行を削除し、単一DB設計である旨と実SDK(`SandboxSync`)での `OPENSANDBOX` 伝搬経路を追記。
- **計画書Task2.2**: `init.sql` 直書きを `zz-apply-schema.sh` 委譲方式に修正（`TEST_DB_NAME` 環境変数対応）。
- **計画書Task2.3**: `SQLITE_GRAPH_PATH` の assert/helper を削除し、`clean_env` sandboxスキップの注記を追加。
- **計画書Task1.3**: 擬似コード冒頭に実SDK API（`SandboxSync`/`RunCommandOpts`）との乖離注記を追加。

## 検証

- LSP diagnostics: 全変更ファイルでエラー0
- 静的検証: `sqlite_graph_path` 不在確認、`clean_env` sandboxスキップのシミュレーション実証、全PythonファイルのASTパース確認
- Ruff lint/format: プッシュ時に自動チェック通過

## 残課題（実機検証が必要）

`SandboxSync.create(image=, metadata=)` が sandbox.yaml の mounts/env をサーバ側で適用するかは SDK 挙動依存。Verification Checklist に沿った実機確認が必要。