### PR TITLE
fix(sandbox): OpenSandbox integrationの乖離を修正

### DIFF
--- a/scripts/sandbox_runner.py
+++ b/scripts/sandbox_runner.py
@@ -95,6 +95,29 @@ def build_profile_env(profile: str) -> dict[str, str]:
         }
     )
     return env
+    _validate_db_host_consistency(env)
+    return env
+
+
+def _validate_db_host_consistency(env: dict[str, str]) -> None:
+    """Validate that all integration DB hosts point to the same host.
+    Raises ValueError if POSTGRES_HOST, NEO4J_URI hostname, and REDIS_URL
+    hostname are not identical.
+    """
+    pg_host = env.get("POSTGRES_HOST")
+    neo4j_uri = env.get("NEO4J_URI", "")
+    redis_url = env.get("REDIS_URL", "")
+
+    neo4j_host = urlparse(neo4j_uri).hostname if neo4j_uri else None
+    redis_host = urlparse(redis_url).hostname if redis_url else None
+
+    hosts = {h for h in (pg_host, neo4j_host, redis_host) if h}
+    if len(hosts) > 1:
+        raise ValueError(
+            f"Integration profile requires all DB hosts to match. "
+            f"Found: POSTGRES_HOST={pg_host}, NEO4J_HOST={neo4j_host}, "
+            f"REDIS_HOST={redis_host}",
+        )
 
 
 def build_network_policy(profile: str) -> NetworkPolicy:

--- a/scripts/sandbox_runner.py
+++ b/scripts/sandbox_runner.py
@@ -94,7 +94,6 @@ def build_profile_env(profile: str) -> dict[str, str]:
             "REDIS_URL": os.environ.get("TEST_REDIS_URL", "redis://host.docker.internal:6379/1"),
         }
     )
-    return env
     _validate_db_host_consistency(env)
     return env
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,7 +62,7 @@ async def neo4j_driver():
     yield driver
     try:
         await driver.close()
-    except Exception as exc:  # noqa: S110
+    except Exception as exc:  # noqa: BLE001
         logging.warning("Neo4j driver close failed during teardown: %s", exc)
 
 
@@ -73,5 +73,5 @@ async def redis_client():
     yield client
     try:
         await client.aclose()
-    except Exception as exc:  # noqa: S110
+    except Exception as exc:  # noqa: BLE001
         logging.warning("Redis client close failed during teardown: %s", exc)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,8 @@ import os
 
 import asyncpg
 import pytest_asyncio
+import redis.asyncio as redis_asyncio
+from neo4j import AsyncGraphDatabase
 
 PG_HOST = os.getenv("POSTGRES_HOST", os.getenv("PG_HOST", "localhost"))
 PG_PORT = int(os.getenv("POSTGRES_PORT", os.getenv("PG_PORT", "5435")))
@@ -43,3 +45,26 @@ async def db_session(postgres_pool):
     yield conn
     await tx.rollback()
     await postgres_pool.release(conn)
+
+
+NEO4J_URI = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "dev_password")
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/1")
+
+
+@pytest_asyncio.fixture
+async def neo4j_driver():
+    """Neo4j async driver fixture."""
+    driver = AsyncGraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+    yield driver
+    await driver.close()
+
+
+@pytest_asyncio.fixture
+async def redis_client():
+    """Redis async client fixture."""
+    client = redis_asyncio.from_url(REDIS_URL)
+    yield client
+    await client.aclose()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ Requires: docker compose up -d postgres
 
 from __future__ import annotations
 
+import logging
 import os
 
 import asyncpg
@@ -59,7 +60,10 @@ async def neo4j_driver():
     """Neo4j async driver fixture."""
     driver = AsyncGraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
     yield driver
-    await driver.close()
+    try:
+        await driver.close()
+    except Exception as exc:  # noqa: S110
+        logging.warning("Neo4j driver close failed during teardown: %s", exc)
 
 
 @pytest_asyncio.fixture
@@ -67,4 +71,7 @@ async def redis_client():
     """Redis async client fixture."""
     client = redis_asyncio.from_url(REDIS_URL)
     yield client
-    await client.aclose()
+    try:
+        await client.aclose()
+    except Exception as exc:  # noqa: S110
+        logging.warning("Redis client close failed during teardown: %s", exc)

--- a/tests/integration/test_neo4j_connection.py
+++ b/tests/integration/test_neo4j_connection.py
@@ -1,0 +1,12 @@
+"""Minimal connectivity test for Neo4j."""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_neo4j_connectivity(neo4j_driver):
+    try:
+        await neo4j_driver.verify_connectivity()
+    except Exception as exc:
+        pytest.skip(f"Neo4j not reachable: {exc}")

--- a/tests/integration/test_redis_connection.py
+++ b/tests/integration/test_redis_connection.py
@@ -1,0 +1,12 @@
+"""Minimal connectivity test for Redis."""
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+async def test_redis_connectivity(redis_client):
+    try:
+        await redis_client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis not reachable: {exc}")

--- a/tests/unit/test_sandbox_runner.py
+++ b/tests/unit/test_sandbox_runner.py
@@ -353,3 +353,39 @@ class TestTeardownSandbox:
         captured = capsys.readouterr()
         assert "Warning" in captured.err
         assert "kill failed" in captured.err
+
+
+class TestValidateDbHostConsistency:
+    def test_all_default_hosts_match(self, runner, monkeypatch):
+        monkeypatch.delenv("TEST_DB_HOST", raising=False)
+        monkeypatch.delenv("TEST_NEO4J_URI", raising=False)
+        monkeypatch.delenv("TEST_REDIS_URL", raising=False)
+
+        env = runner.build_profile_env("integration")
+        runner._validate_db_host_consistency(env)
+
+    def test_all_custom_hosts_match(self, runner, monkeypatch):
+        monkeypatch.setenv("TEST_DB_HOST", "my-host")
+        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://my-host:7687")
+        monkeypatch.setenv("TEST_REDIS_URL", "redis://my-host:6379/1")
+
+        env = runner.build_profile_env("integration")
+        runner._validate_db_host_consistency(env)
+
+    def test_mismatch_postgres_neo4j_raises(self, runner, monkeypatch):
+        monkeypatch.setenv("TEST_DB_HOST", "pg-host")
+        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://neo4j-host:7687")
+        monkeypatch.setenv("TEST_REDIS_URL", "redis://pg-host:6379/1")
+
+        env = runner.build_profile_env("integration")
+        with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
+            runner._validate_db_host_consistency(env)
+
+    def test_mismatch_postgres_redis_raises(self, runner, monkeypatch):
+        monkeypatch.setenv("TEST_DB_HOST", "pg-host")
+        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://pg-host:7687")
+        monkeypatch.setenv("TEST_REDIS_URL", "redis://redis-host:6379/1")
+
+        env = runner.build_profile_env("integration")
+        with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
+            runner._validate_db_host_consistency(env)

--- a/tests/unit/test_sandbox_runner.py
+++ b/tests/unit/test_sandbox_runner.py
@@ -390,8 +390,10 @@ class TestValidateDbHostConsistency:
 
     def test_build_profile_env_validates_via_integration(self, runner, monkeypatch):
         monkeypatch.setenv("TEST_DB_HOST", "pg-host")
-        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://neo4j-host:7687")
+        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://pg-host:7687")
         monkeypatch.setenv("TEST_REDIS_URL", "redis://pg-host:6379/1")
 
-        with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
-            runner.build_profile_env("integration")
+        env = runner.build_profile_env("integration")
+        assert env["POSTGRES_HOST"] == "pg-host"
+        assert env["NEO4J_URI"] == "bolt://pg-host:7687"
+        assert env["REDIS_URL"] == "redis://pg-host:6379/1"

--- a/tests/unit/test_sandbox_runner.py
+++ b/tests/unit/test_sandbox_runner.py
@@ -377,15 +377,21 @@ class TestValidateDbHostConsistency:
         monkeypatch.setenv("TEST_NEO4J_URI", "bolt://neo4j-host:7687")
         monkeypatch.setenv("TEST_REDIS_URL", "redis://pg-host:6379/1")
 
-        env = runner.build_profile_env("integration")
         with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
-            runner._validate_db_host_consistency(env)
+            runner.build_profile_env("integration")
 
     def test_mismatch_postgres_redis_raises(self, runner, monkeypatch):
         monkeypatch.setenv("TEST_DB_HOST", "pg-host")
         monkeypatch.setenv("TEST_NEO4J_URI", "bolt://pg-host:7687")
         monkeypatch.setenv("TEST_REDIS_URL", "redis://redis-host:6379/1")
 
-        env = runner.build_profile_env("integration")
         with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
-            runner._validate_db_host_consistency(env)
+            runner.build_profile_env("integration")
+
+    def test_build_profile_env_validates_via_integration(self, runner, monkeypatch):
+        monkeypatch.setenv("TEST_DB_HOST", "pg-host")
+        monkeypatch.setenv("TEST_NEO4J_URI", "bolt://neo4j-host:7687")
+        monkeypatch.setenv("TEST_REDIS_URL", "redis://pg-host:6379/1")
+
+        with pytest.raises(ValueError, match="Integration profile requires all DB hosts to match"):
+            runner.build_profile_env("integration")


### PR DESCRIPTION
## 変更内容

### 1. integration profileの単一DBホスト制約を追加
- <code>scripts/sandbox_runner.py</code> に <code>_validate_db_host_consistency()</code> を追加
- POSTGRES_HOST / NEO4J_URI hostname / REDIS_URL hostname が一致しない場合、<code>ValueError</code> を投げる
- 単体テスト (<code>TestValidateDbHostConsistency</code>) を4ケース追加

### 2. Neo4j/Redis の実接続 integration テストを追加
- <code>tests/integration/conftest.py</code> に async fixture (<code>neo4j_driver</code>, <code>redis_client</code>) を追加
- <code>test_neo4j_connection.py</code> / <code>test_redis_connection.py</code> で実接続を確認
- 接続失敗時は <code>pytest.skip</code> でグレースフルにスキップ

## 検証結果



## 対応する乖離

- <code>TEST_DB_HOST</code> は Postgres と egress のみ反映され、Neo4j/Redis は別ホストを指しても検証されていなかった → 実行時に <code>ValueError</code> で検証
- Phase 2 の Neo4j/Redis 実接続 coverage が不足していた → integration テストを追加