### PR TITLE
fix: source_metadataのdatetimeシリアライズ失敗を修正

### DIFF
--- a/src/context_store/storage/postgres.py
+++ b/src/context_store/storage/postgres.py
@@ -14,6 +14,7 @@ from context_store.storage.migrations.runner import MigrationRunner
 from context_store.storage.postgres_helpers import (
     _content_hash,
     _embedding_to_pg,
+    _json_default,
     _record_to_memory,
 )
 from context_store.storage.protocols import ALLOWED_SORT_COLUMNS, MemoryFilters, StorageError
@@ -107,7 +108,7 @@ class PostgresStorageAdapter:
                         memory.content,
                         memory.memory_type.value,
                         memory.source_type.value,
-                        json.dumps(memory.source_metadata),
+                        json.dumps(memory.source_metadata, default=_json_default),
                         embedding_str,
                         memory.semantic_relevance,
                         memory.importance_score,
@@ -231,7 +232,7 @@ class PostgresStorageAdapter:
                 set_parts.append(f"{col} = ${len(params)}::vector")
                 continue
             if col == "source_metadata" and isinstance(val, dict):
-                val = json.dumps(val)
+                val = json.dumps(val, default=_json_default)
                 params.append(val)
                 set_parts.append(f"{col} = ${len(params)}::jsonb")
                 continue

--- a/src/context_store/storage/postgres_helpers.py
+++ b/src/context_store/storage/postgres_helpers.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime
+from enum import Enum
 from typing import Any
+from uuid import UUID
 
 from context_store.models.memory import Memory, MemoryType, SourceType
 
@@ -13,6 +16,25 @@ def _content_hash(content: str) -> str:
     """Create the canonical content hash stored in PostgreSQL."""
     return hashlib.sha256(content.encode()).hexdigest()
 
+
+def _json_default(obj: Any) -> Any:
+    """JSON serialization fallback for datetime, UUID, Enum, and bytes.
+
+    Use as ``json.dumps(data, default=_json_default)`` anywhere
+    a dict value may contain non-primitive Python objects.
+    """
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, UUID):
+        return str(obj)
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, bytes):
+        try:
+            return obj.decode("utf-8")
+        except UnicodeDecodeError:
+            return obj.hex()
+    return str(obj)
 
 def _parse_embedding(raw: object) -> list[float]:
     """Parse a pgvector value returned by a PostgreSQL client into list[float]."""

--- a/src/context_store/storage/postgres_helpers.py
+++ b/src/context_store/storage/postgres_helpers.py
@@ -36,6 +36,7 @@ def _json_default(obj: Any) -> Any:
             return obj.hex()
     return str(obj)
 
+
 def _parse_embedding(raw: object) -> list[float]:
     """Parse a pgvector value returned by a PostgreSQL client into list[float]."""
     if raw is None:

--- a/src/context_store/storage/sqlite.py
+++ b/src/context_store/storage/sqlite.py
@@ -19,6 +19,7 @@ import aiosqlite
 from context_store.config import Settings
 from context_store.models.memory import Memory, MemorySource, MemoryType, ScoredMemory, SourceType
 from context_store.storage.migrations.runner import MigrationRunner
+from context_store.storage.postgres_helpers import _json_default
 from context_store.storage.protocols import ALLOWED_SORT_COLUMNS, MemoryFilters, StorageError
 from context_store.sync.outbox_writer import OutboxWriter
 from context_store.utils.stale_lock import StaleAwareFileLock
@@ -376,7 +377,7 @@ class SQLiteStorageAdapter:
                         memory.content,
                         memory.memory_type.value,
                         memory.source_type.value,
-                        json.dumps(memory.source_metadata),
+                        json.dumps(memory.source_metadata, default=_json_default),
                         memory.semantic_relevance,
                         memory.importance_score,
                         memory.access_count,
@@ -610,7 +611,7 @@ class SQLiteStorageAdapter:
                             code="INVALID_PARAMETER",
                         )
                     try:
-                        val = json.dumps(val)
+                        val = json.dumps(val, default=_json_default)
                     except (TypeError, ValueError) as exc:
                         raise StorageError(
                             f"Failed to serialise {col}: {exc}",

--- a/src/context_store/storage/sqlite_graph.py
+++ b/src/context_store/storage/sqlite_graph.py
@@ -35,6 +35,7 @@ import aiosqlite
 
 from context_store.models.graph import Edge, GraphResult
 from context_store.storage.migrations.runner import MigrationRunner
+from context_store.storage.postgres_helpers import _json_default
 from context_store.utils.sqlite_interrupt import SafeSqliteInterruptCtx
 from context_store.utils.stale_lock import StaleAwareFileLock
 
@@ -131,7 +132,7 @@ class SQLiteGraphAdapter:
 
     async def create_node(self, memory_id: str, metadata: dict[str, Any]) -> None:
         """Create or upsert a graph node."""
-        meta_json = json.dumps(metadata)
+        meta_json = json.dumps(metadata, default=_json_default)
         async with self._connect() as conn:
             await conn.execute(
                 """
@@ -153,7 +154,7 @@ class SQLiteGraphAdapter:
 
         Requires both nodes to exist (enforced by FOREIGN KEY constraints).
         """
-        props_json = json.dumps(props)
+        props_json = json.dumps(props, default=_json_default)
         async with self._connect() as conn:
             await conn.execute(
                 """
@@ -177,7 +178,7 @@ class SQLiteGraphAdapter:
                 e["from_id"],
                 e["to_id"],
                 e["edge_type"],
-                json.dumps(e.get("props") or {}),
+                json.dumps(e.get("props") or {}, default=_json_default),
             )
             for e in edges
         ]

--- a/src/context_store/sync/outbox_writer.py
+++ b/src/context_store/sync/outbox_writer.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from typing import Any, Protocol, get_args
 
+from context_store.storage.postgres_helpers import _json_default
 from context_store.sync.models import EventType
 
 _ALLOWED_EVENT_TYPES = frozenset(get_args(EventType))
@@ -64,7 +65,7 @@ class PostgresOutboxWriter:
             self._SQL,
             event_type,
             memory_id,
-            json.dumps(payload or {}),
+            json.dumps(payload or {}, default=_json_default),
         )
 
 
@@ -92,6 +93,6 @@ class SqliteOutboxWriter:
                 str(uuid.uuid4()),
                 event_type,
                 memory_id,
-                json.dumps(payload or {}),
+                json.dumps(payload or {}, default=_json_default),
             ),
         )


### PR DESCRIPTION
## 概要

`source_metadata` 等の dict に `datetime` オブジェクトが混入した場合、`json.dumps` に `default` ハンドラがなく `TypeError: Object of type datetime is not JSON serializable` が発生する問題を修正。

## 根本原因

`ingestion/pipeline.py` には `_serialize_meta`（datetime/UUID/Enum/bytes 対応）が既に存在していたが、storage 層の `json.dumps` 呼び出しには適用されていなかった。

## 修正内容

### 追加
- `storage/postgres_helpers.py`: 共通ヘルパー `_json_default` を追加（datetime → isoformat / UUID → str / Enum → value / bytes → decode or hex / その他 → str）

### 適用箇所
| ファイル | 箇所 |
|---|---|
| `storage/sqlite.py` | `save_memory`・`update_memory` |
| `storage/postgres.py` | `save_memory`・`update_memory` |
| `storage/sqlite_graph.py` | `create_node`・`create_edge`・`create_edges_batch` |
| `sync/outbox_writer.py` | `PostgresOutboxWriter`・`SqliteOutboxWriter` |

## 検証

- `ruff check` / `mypy`: クリーン
- unit tests: `test_sqlite_storage` / `test_postgres_helpers_robustness` / `test_sqlite_graph` — **126 passed**