### PR TITLE
fix(outbox): asyncpgが返すJSONB文字列payloadを正しくdictに変換

### DIFF
--- a/src/context_store/sync/outbox_reader.py
+++ b/src/context_store/sync/outbox_reader.py
@@ -179,7 +179,7 @@ class PostgresOutboxReader:
                 id=str(r["id"]),
                 event_type=r["event_type"],
                 memory_id=r["memory_id"],
-                payload=dict(r["payload"]) if r["payload"] else {},
+                payload=_postgres_payload_to_dict(r["payload"]),
                 status="PROCESSING",
                 retry_count=r["retry_count"],
                 next_retry_at=r["next_retry_at"],
@@ -236,7 +236,7 @@ class PostgresOutboxReader:
                 id=str(r["id"]),
                 event_type=r["event_type"],
                 memory_id=r["memory_id"],
-                payload=dict(r["payload"]) if r["payload"] else {},
+                payload=_postgres_payload_to_dict(r["payload"]),
                 status=r["status"],
                 retry_count=r["retry_count"],
                 next_retry_at=r["next_retry_at"],
@@ -376,6 +376,21 @@ def _supabase_row_to_event(row: dict[str, Any]) -> OutboxEvent:
         created_at=_parse_dt(row.get("created_at")),
         updated_at=_parse_dt(row.get("updated_at")),
     )
+
+
+def _postgres_payload_to_dict(raw: Any) -> dict[str, Any]:
+    """asyncpg が JSONB を文字列で返す場合も dict に変換する。"""
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    if isinstance(raw, dict):
+        return raw
+    return {}
 
 
 def _parse_dt(s: str | None) -> datetime:

--- a/src/context_store/sync/outbox_reader.py
+++ b/src/context_store/sync/outbox_reader.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
 import aiosqlite
 
 from context_store.sync.models import EventStatus, OutboxEvent
+
+logger = logging.getLogger(__name__)
 
 
 class OutboxReader(Protocol):
@@ -385,11 +388,16 @@ def _postgres_payload_to_dict(raw: Any) -> dict[str, Any]:
     if isinstance(raw, str):
         try:
             parsed = json.loads(raw)
-            return parsed if isinstance(parsed, dict) else {}
+            if isinstance(parsed, dict):
+                return parsed
+            logger.warning("Outbox payload is not a JSON object: %r", raw)
+            return {}
         except json.JSONDecodeError:
+            logger.warning("Outbox payload is not valid JSON: %r", raw)
             return {}
     if isinstance(raw, dict):
         return raw
+    logger.warning("Outbox payload has unexpected type %s: %r", type(raw).__name__, raw)
     return {}
 
 

--- a/tests/unit/sync/test_outbox_reader.py
+++ b/tests/unit/sync/test_outbox_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 import aiosqlite
@@ -264,3 +265,27 @@ async def test_postgres_reader_fetch_all_actionable_parses_string_payload() -> N
     assert len(events) == 1
     assert dict(events[0].payload) == {"key": "value"}
     fake_conn.fetch.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected", "expect_warning"),
+    [
+        (None, {}, False),
+        ('{"key": "value"}', {"key": "value"}, False),
+        ("{}", {}, False),
+        ("not-json", {}, True),
+        ("[]", {}, True),
+        ("42", {}, True),
+        ({"key": "value"}, {"key": "value"}, False),
+        (123, {}, True),
+    ],
+)
+def test_postgres_payload_to_dict(raw, expected, expect_warning, caplog) -> None:
+    """_postgres_payload_to_dict が文字列・dict・None・不正値を正しく処理する。"""
+    from context_store.sync.outbox_reader import _postgres_payload_to_dict
+
+    with caplog.at_level(logging.WARNING, logger="context_store.sync.outbox_reader"):
+        result = _postgres_payload_to_dict(raw)
+
+    assert result == expected
+    assert bool(caplog.records) == expect_warning

--- a/tests/unit/sync/test_outbox_reader.py
+++ b/tests/unit/sync/test_outbox_reader.py
@@ -225,3 +225,42 @@ async def test_postgres_reader_fetch_pending_parses_string_payload() -> None:
     assert len(events) == 1
     assert dict(events[0].payload) == {"key": "value"}
     fake_conn.fetch.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_postgres_reader_fetch_all_actionable_parses_string_payload() -> None:
+    """asyncpg が JSONB を文字列で返しても fetch_all_actionable が dict にパースする。"""
+    from datetime import datetime, timezone
+    from unittest.mock import AsyncMock, MagicMock
+
+    from context_store.sync.outbox_reader import PostgresOutboxReader
+
+    now = datetime.now(timezone.utc)
+    fake_conn = MagicMock()
+    fake_conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "event_type": "SYNC_MEMORY",
+                "memory_id": "22222222-2222-2222-2222-222222222222",
+                "payload": '{"key": "value"}',
+                "status": "PENDING",
+                "retry_count": 0,
+                "next_retry_at": now,
+                "created_at": now,
+                "updated_at": now,
+                "error_message": None,
+            }
+        ]
+    )
+    fake_pool = MagicMock()
+    fake_pool.acquire = MagicMock(return_value=fake_conn)
+    fake_conn.__aenter__ = AsyncMock(return_value=fake_conn)
+    fake_conn.__aexit__ = AsyncMock(return_value=False)
+
+    reader = PostgresOutboxReader(pool=fake_pool)
+    events = await reader.fetch_all_actionable()
+
+    assert len(events) == 1
+    assert dict(events[0].payload) == {"key": "value"}
+    fake_conn.fetch.assert_called_once()

--- a/tests/unit/sync/test_outbox_reader.py
+++ b/tests/unit/sync/test_outbox_reader.py
@@ -186,3 +186,42 @@ async def test_supabase_reader_reset_stuck_processing_calls_rpc() -> None:
         {"p_threshold_seconds": 60, "p_max_retries": 10},
     )
     assert n == 2
+
+
+@pytest.mark.asyncio
+async def test_postgres_reader_fetch_pending_parses_string_payload() -> None:
+    """asyncpg が JSONB を文字列で返しても payload が dict としてパースされる。"""
+    from datetime import datetime, timezone
+    from unittest.mock import AsyncMock, MagicMock
+
+    from context_store.sync.outbox_reader import PostgresOutboxReader
+
+    now = datetime.now(timezone.utc)
+    fake_conn = MagicMock()
+    fake_conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "event_type": "SYNC_MEMORY",
+                "memory_id": "22222222-2222-2222-2222-222222222222",
+                # asyncpg は JSONB を文字列として返すことがある
+                "payload": '{"key": "value"}',
+                "retry_count": 0,
+                "next_retry_at": now,
+                "created_at": now,
+                "updated_at": now,
+                "error_message": None,
+            }
+        ]
+    )
+    fake_pool = MagicMock()
+    fake_pool.acquire = MagicMock(return_value=fake_conn)
+    fake_conn.__aenter__ = AsyncMock(return_value=fake_conn)
+    fake_conn.__aexit__ = AsyncMock(return_value=False)
+
+    reader = PostgresOutboxReader(pool=fake_pool)
+    events = await reader.fetch_pending(limit=10)
+
+    assert len(events) == 1
+    assert dict(events[0].payload) == {"key": "value"}
+    fake_conn.fetch.assert_called_once()


### PR DESCRIPTION
PostgresOutboxReader.fetch_pending / fetch_all_actionable で、 asyncpg が JSONB カラムを文字列として返す場合に dict() 変換が
失敗し、ValueError が発生していた。

- json.loads() を使った _postgres_payload_to_dict ヘルパーを追加
- 文字列・dict・None それぞれを安全に処理
- 該当ケースを再現するユニットテストを追加