### PR TITLE
fix(config): Supabase+Graph時のGRAPH_SYNC_MODE誤設定を恒久対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,13 @@ FORCE_CACHE_COHERENCE_IN_READ_ONLY=false
 # ==============================================================================
 # sync: GraphLinker が Neo4j に直接同期書き込み (デフォルト)
 # async_outbox: Storage TX 内で Outbox に書き込み、Worker が非同期で Neo4j 同期
+#
+# ⚠️ 必須制約: STORAGE_BACKEND=supabase かつ GRAPH_ENABLED=true の場合、
+#    このモードは async_outbox でなければ起動時に ValidationError で失敗します
+#    (Neo4j Bolt プロトコルは Supabase の HTTPS Data API 越しに使用できないため)。
+#    scripts/bootstrap.sh 経由のセットアップでは自動的に async_outbox へ補正されますが、
+#    この .env.example を手動でコピー・編集する場合は自分で設定してください。
+#    詳細: docs/troubleshooting/supabase-graph-sync-mode.md
 GRAPH_SYNC_MODE=sync
 #OUTBOX_POLL_INTERVAL_SECONDS=5.0
 #OUTBOX_BATCH_SIZE=100

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ ChronosGraph 本体で利用する環境変数の一覧です。ツール実行�
 | `EMBEDDING_PROVIDER` | `local-model` | デフォルト可 | 埋め込みプロバイダー (`local-model` / `openai` / `litellm` / `custom-api`) |
 | `LOCAL_MODEL_NAME` | `cl-nagoya/ruri-v3-310m` | デフォルト可 | ローカルモデル名 (768次元) |
 | `EMBEDDING_DIMENSION` | `768` | デフォルト可 | 埋め込みベクトル次元数 (例: 768) |
-| `GRAPH_ENABLED` | `false` | デフォルト可 | グラフ関係性機能の有効化。SQLite では内部グラフ、PostgreSQL では Neo4j を使用。Supabase では `graph_sync_mode=async_outbox` のみ対応 |
+| `GRAPH_ENABLED` | `false` | デフォルト可 | グラフ関係性機能の有効化。SQLite では内部グラフ、PostgreSQL では Neo4j を使用。Supabase では `graph_sync_mode=async_outbox` のみ対応（[詳細](docs/troubleshooting/supabase-graph-sync-mode.md)） |
 | `GRAPH_SYNC_MODE` | `sync` | デフォルト可 | グラフの同期モード (`sync` = 直接同期 / `async_outbox` = Outbox を介した非同期同期) |
 | `OUTBOX_POLL_INTERVAL_SECONDS` | `5.0` | デフォルト可 | **[async_outbox用]** Outbox ワーカーのポーリング間隔秒数 |
 | `OUTBOX_BATCH_SIZE` | `100` | デフォルト可 | **[async_outbox用]** 1回のポーリングで処理する最大イベント数 |

--- a/docs/troubleshooting/supabase-graph-sync-mode.md
+++ b/docs/troubleshooting/supabase-graph-sync-mode.md
@@ -6,7 +6,7 @@
 
 `memory_save` などのツールを呼び出すと、以下のようなエラーが返ります。
 
-```
+```text
 Error executing tool memory_save: 1 validation error for Settings
 Value error, Supabase + graph の組み合わせには graph_sync_mode='async_outbox' が必須です
 (Neo4j Bolt は HTTPS にカプセル化できないため)。

--- a/docs/troubleshooting/supabase-graph-sync-mode.md
+++ b/docs/troubleshooting/supabase-graph-sync-mode.md
@@ -1,0 +1,95 @@
+# Troubleshooting: Supabase + Graph 有効時の `GRAPH_SYNC_MODE` 起動エラー
+
+`STORAGE_BACKEND=supabase` かつ `GRAPH_ENABLED=true` の構成で、`GRAPH_SYNC_MODE` が `sync`（デフォルト値）のままになっていると、サーバー起動時（正確には `Settings` 構築時）に `ValidationError` が発生し、`memory_save` を含む全てのメモリ操作が失敗します。
+
+## 🚩 問題の概要
+
+`memory_save` などのツールを呼び出すと、以下のようなエラーが返ります。
+
+```
+Error executing tool memory_save: 1 validation error for Settings
+Value error, Supabase + graph の組み合わせには graph_sync_mode='async_outbox' が必須です
+(Neo4j Bolt は HTTPS にカプセル化できないため)。
+input_value={'storage_backend': 'supabase', ..., 'graph_sync_mode': 'sync'}
+```
+
+`scripts/check_connectivity.py` を実行した場合も、同じ設定であれば診断メッセージの前にこの検証エラーで停止します。
+
+## 🔍 原因の特定
+
+検証ロジックは `src/context_store/config.py` の `Settings._validate_graph_sync_mode`（`@model_validator(mode="after")`）にあります。
+
+```python
+if (
+    self.storage_backend == "supabase"
+    and self.graph_enabled
+    and self.graph_sync_mode != "async_outbox"
+):
+    raise ValueError(
+        "Supabase + graph の組み合わせには graph_sync_mode='async_outbox' が必須です "
+        "(Neo4j Bolt は HTTPS にカプセル化できないため)。"
+    )
+```
+
+これは意図的なフェイルファスト設計です。Supabase は Data API（HTTPS/PostgREST）経由でのみアクセスでき、Neo4j の Bolt プロトコル（TCP）をそのトンネルに乗せることができません。そのため `sync`（GraphLinker が Neo4j に直接同期書き込み）は Supabase 環境では成立せず、`async_outbox`（Storage トランザクション内で Outbox テーブルに書き込み、専用 Worker が非同期で Neo4j に同期）を使う必要があります。
+
+### なぜこの状態になるのか
+
+- `scripts/bootstrap.sh` 経由でセットアップした場合は、以下の自動補正ロジックが働くため通常発生しません。
+
+  ```bash
+  # Correlation validation auto-correction
+  if [ "$BACKEND" = "supabase" ] && [ "$GRAPH_ENABLED" = "true" ]; then
+      if [ "$GRAPH_SYNC_MODE" != "async_outbox" ]; then
+          echo "Supabase combined with graph_enabled=true requires async_outbox mode. Overriding graph_sync_mode to async_outbox."
+          GRAPH_SYNC_MODE="async_outbox"
+      fi
+  fi
+  ```
+
+- 一方、`.env.example` をそのまま手動でコピー・編集し、`STORAGE_BACKEND=supabase` と `GRAPH_ENABLED=true` だけを設定して `GRAPH_SYNC_MODE=sync`（デフォルト値）を変更し忘れると、この不整合な状態になります。`bootstrap.sh` を経由しない限り自動補正は働きません。
+
+## 🛠 解決策
+
+### 1. `.env` を直接修正する（最短）
+
+```bash
+# .env 内の該当行を書き換える
+GRAPH_SYNC_MODE=async_outbox
+```
+
+合わせて Outbox ワーカー関連の設定（コメントアウトされている場合は解除）も確認してください。
+
+```env
+OUTBOX_POLL_INTERVAL_SECONDS=5.0
+OUTBOX_BATCH_SIZE=100
+OUTBOX_MAX_RETRIES=10
+OUTBOX_BACKOFF_BASE_SECONDS=1.0
+OUTBOX_BACKOFF_MAX_SECONDS=60.0
+```
+
+### 2. `bootstrap.sh` を再実行する（推奨）
+
+`--graph-sync-mode` を明示するか、`--backend supabase --graph true` を渡すだけで自動補正されます。
+
+```bash
+bash scripts/bootstrap.sh --backend supabase --graph true --embedding local-model
+```
+
+### 3. グラフ機能自体が不要な場合
+
+グラフ関係性を使わないのであれば、`GRAPH_ENABLED=false` に落とすことでも解消します（この場合 `GRAPH_SYNC_MODE` の値は無視されます）。
+
+```bash
+GRAPH_ENABLED=false
+```
+
+## 💡 設定のヒント (ChronosGraph 特有)
+
+修正後は `scripts/check_connectivity.py` で設定が正しく反映されたか確認できます。
+
+```bash
+uv run python scripts/check_connectivity.py
+```
+
+このスクリプトは `Settings()` の構築失敗（本問題を含む）を検知した場合、生の traceback ではなく本ドキュメントへの案内を含むヒントを表示するようになっています。

--- a/scripts/check_connectivity.py
+++ b/scripts/check_connectivity.py
@@ -43,12 +43,14 @@ async def check_connectivity() -> None:
         settings = Settings()
     except Exception as e:
         print(f"❌ Settings validation failed: {sanitize_error(e)}")
-        print(
-            "\n💡 Hint: If STORAGE_BACKEND=supabase and GRAPH_ENABLED=true, "
-            "GRAPH_SYNC_MODE must be 'async_outbox' (Neo4j Bolt cannot be tunneled "
-            "over Supabase's HTTPS-only Data API). See "
-            "docs/troubleshooting/supabase-graph-sync-mode.md for details."
-        )
+        error_str = str(e).lower()
+        if "graph_sync_mode" in error_str or "async_outbox" in error_str:
+            print(
+                "\n💡 Hint: If STORAGE_BACKEND=supabase and GRAPH_ENABLED=true, "
+                "GRAPH_SYNC_MODE must be 'async_outbox' (Neo4j Bolt cannot be tunneled "
+                "over Supabase's HTTPS-only Data API). See "
+                "docs/troubleshooting/supabase-graph-sync-mode.md for details."
+            )
         sys.exit(1)
     print(f"Checking connectivity for storage_backend={settings.storage_backend}...")
 

--- a/scripts/check_connectivity.py
+++ b/scripts/check_connectivity.py
@@ -39,7 +39,17 @@ def is_placeholder(val: Any) -> bool:
 
 
 async def check_connectivity() -> None:
-    settings = Settings()
+    try:
+        settings = Settings()
+    except Exception as e:
+        print(f"❌ Settings validation failed: {sanitize_error(e)}")
+        print(
+            "\n💡 Hint: If STORAGE_BACKEND=supabase and GRAPH_ENABLED=true, "
+            "GRAPH_SYNC_MODE must be 'async_outbox' (Neo4j Bolt cannot be tunneled "
+            "over Supabase's HTTPS-only Data API). See "
+            "docs/troubleshooting/supabase-graph-sync-mode.md for details."
+        )
+        sys.exit(1)
     print(f"Checking connectivity for storage_backend={settings.storage_backend}...")
 
     # 1. Check for placeholders or unset values in configuration

--- a/scripts/check_connectivity.py
+++ b/scripts/check_connectivity.py
@@ -3,6 +3,8 @@ import re
 import sys
 from typing import Any
 
+from pydantic import ValidationError
+
 from context_store.config import Settings
 
 
@@ -19,6 +21,19 @@ def sanitize_error(e: Exception) -> str:
     msg = str(e)
     # パスワードやDSNが混じりやすいため、簡易的なマスクを適用
     return re.sub(r":([^@/ ]+)@", ":****@", msg)
+
+
+def sanitize_validation_error(e: ValidationError) -> str:
+    """Pydantic ValidationError から機密情報を含まない簡潔なメッセージを組み立てる。"""
+    parts: list[str] = []
+    for err in e.errors():
+        loc = ".".join(str(x) for x in err.get("loc", []))
+        msg = err.get("msg", "")
+        if loc:
+            parts.append(f"{loc}: {msg}")
+        else:
+            parts.append(msg)
+    return "\n".join(parts)
 
 
 def is_placeholder(val: Any) -> bool:
@@ -41,16 +56,20 @@ def is_placeholder(val: Any) -> bool:
 async def check_connectivity() -> None:
     try:
         settings = Settings()
-    except Exception as e:
-        print(f"❌ Settings validation failed: {sanitize_error(e)}")
-        error_str = str(e).lower()
-        if "graph_sync_mode" in error_str or "async_outbox" in error_str:
-            print(
-                "\n💡 Hint: If STORAGE_BACKEND=supabase and GRAPH_ENABLED=true, "
-                "GRAPH_SYNC_MODE must be 'async_outbox' (Neo4j Bolt cannot be tunneled "
-                "over Supabase's HTTPS-only Data API). See "
-                "docs/troubleshooting/supabase-graph-sync-mode.md for details."
-            )
+    except ValidationError as e:
+        print(f"❌ Settings validation failed: {sanitize_validation_error(e)}")
+        # Supabase + graph_enabled=true かつ graph_sync_mode != async_outbox の
+        # 固有の組み合わせ不一致の場合だけ、トラブルシューティングガイドを提示する。
+        for err in e.errors():
+            msg = err.get("msg", "").lower()
+            if "supabase + graph" in msg and "graph_sync_mode='async_outbox'" in msg:
+                print(
+                    "\n💡 Hint: If STORAGE_BACKEND=supabase and GRAPH_ENABLED=true, "
+                    "GRAPH_SYNC_MODE must be 'async_outbox' (Neo4j Bolt cannot be tunneled "
+                    "over Supabase's HTTPS-only Data API). See "
+                    "docs/troubleshooting/supabase-graph-sync-mode.md for details."
+                )
+                break
         sys.exit(1)
     print(f"Checking connectivity for storage_backend={settings.storage_backend}...")
 


### PR DESCRIPTION
memory_save 等が "Supabase + graph の組み合わせには graph_sync_mode='async_outbox' が必須です" という ValidationError で失敗する事例を確認。scripts/bootstrap.sh には 既に自動補正ロジックがあるが、.env.example を手動でコピー・編集した場合はこの
制約が伝わらず誤設定に陥ることが根本原因。

- .env.example: GRAPH_SYNC_MODE=sync の直前に必須制約の警告コメントを追加(再発防止)
- scripts/check_connectivity.py: Settings() 構築失敗時に生の traceback ではなく sanitize 済みエラー + 具体的なヒントを表示するよう防御的処理を追加
- docs/troubleshooting/supabase-graph-sync-mode.md: 既存の litellm-cloudflare-typo.md と同様の構成で、原因・解決策を文書化。 README.md の GRAPH_ENABLED 行からリンク